### PR TITLE
fix: add missing joblib dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pandas>=1.3.0
 numpy>=1.21.0
 
 # Machine Learning
+joblib>=1.2.0
 scikit-learn>=1.0.0
 lightgbm>=3.3.0
 torch>=2.0.0


### PR DESCRIPTION
 imports `joblib` at the top level and uses `joblib.load()` to deserialize model artifacts, but `joblib` was not declared in `requirements.txt`.

This causes a `ModuleNotFoundError` for users who run `pip install -r requirements.txt` without having scikit-learn (which bundles joblib as a transitive dependency) already installed.

**Fix:** Add `joblib>=1.2.0` to the Machine Learning section of `requirements.txt`.