### PR TITLE
TST: Add pytest-cov to CI fast-test tier for coverage tracking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+source = src, api
+omit =
+    */tests/*
+    */__pycache__/*
+    */conftest.py
+    setup.py
+
+[report]
+show_missing = true
+skip_covered = false
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:
+    raise NotImplementedError

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Run tests
-        run: pytest tests/ -v --tb=short
+        run: pytest tests/ -v --tb=short -m "not slow" --cov=src --cov=api --cov-report=term-missing

--- a/doc/whatsnew/v1.0.0.rst
+++ b/doc/whatsnew/v1.0.0.rst
@@ -111,6 +111,8 @@ Test suite
 - Added ``tests/test_traditional_methods.py`` — 49 unit tests for the core bioinformatics layer in ``src/traditional_methods.py``: ORF detection on both strands, RBS scoring, codon model building, codon bias ratio, Interpolated Markov Model construction and scoring, score normalization, and combined score calculation (:issue:`14`)
 - Added ``tests/fixtures/sequences/``, ``tests/fixtures/gff/``, ``tests/fixtures/models/`` — fixture directory scaffold for future synthetic sequences, reference annotations, and mock model files (:issue:`47`)
 - Added ``tests/integration/`` — package for slow end-to-end pipeline tests (:issue:`47`)
+- Added ``.coveragerc`` — coverage configuration: measures ``src/`` and ``api/``, excludes test scaffolding and boilerplate (:issue:`66`)
+- Updated CI ``Run tests`` step to report coverage via ``pytest-cov`` (``--cov=src --cov=api --cov-report=term-missing``) and exclude ``@pytest.mark.slow`` tests from the fast tier (:issue:`66`)
 
 CI/CD
 ^^^^^


### PR DESCRIPTION
## Summary

- Updates the CI `Run tests` step to run `pytest` with `--cov=src --cov=api --cov-report=term-missing`, printing a per-file missing-line coverage report on every CI run
- Adds `-m "not slow"` to exclude `@pytest.mark.slow` tests from the fast tier (aligns CI with the two-tier test strategy documented in `prompts/role_tester.md`)
- Adds `.coveragerc` to configure coverage source boundaries and exclude boilerplate lines (`__repr__`, `if __name__ == "__main__"`, `raise NotImplementedError`)
- `pytest-cov>=3.0.0` was already present in `requirements-dev.txt` — no new dependencies

## Why

Without coverage measurement in CI there is no signal when a PR deletes tests or adds unreachable code. This change makes coverage visible on every run. A `--cov-fail-under` threshold will be added in a follow-up PR once the baseline is measured from CI output.

## Test plan

- [ ] CI passes on Python 3.9, 3.10, 3.11
- [ ] Coverage report appears in CI `Run tests` step output
- [ ] `@pytest.mark.slow` tests are excluded from this tier (none exist yet, so no change in test count)

Closes #66