### PR TITLE
TST: Unit tests for GENOME_CATALOG integrity and config helpers

### DIFF
--- a/doc/whatsnew/v1.0.0.rst
+++ b/doc/whatsnew/v1.0.0.rst
@@ -113,6 +113,7 @@ Test suite
 - Added ``tests/integration/`` — package for slow end-to-end pipeline tests (:issue:`47`)
 - Added ``.coveragerc`` — coverage configuration: measures ``src/`` and ``api/``, excludes test scaffolding and boilerplate (:issue:`66`)
 - Updated CI ``Run tests`` step to report coverage via ``pytest-cov`` (``--cov=src --cov=api --cov-report=term-missing``) and exclude ``@pytest.mark.slow`` tests from the fast tier (:issue:`66`)
+- Added ``tests/test_config.py`` — 32 tests covering ``GENOME_CATALOG`` integrity (100 entries, unique IDs, required keys, known groups), ``TEST_GENOMES`` (15 entries, no duplicates, bacteria + archaea), helper functions ``get_genome_by_id()``, ``get_genome_by_accession()``, ``list_genomes_by_group()``, and scoring constant sanity checks (:issue:`33`)
 
 CI/CD
 ^^^^^

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for src/config.py.
+
+Covers GENOME_CATALOG integrity constraints and the three helper functions:
+get_genome_by_id(), get_genome_by_accession(), list_genomes_by_group().
+"""
+
+import pytest
+
+from src.config import (
+    FIRST_FILTER_THRESHOLD,
+    GENOME_CATALOG,
+    KNOWN_RBS_MOTIFS,
+    MIN_ORF_LENGTH,
+    SCORE_WEIGHTS,
+    SECOND_FILTER_THRESHOLD,
+    START_CODONS,
+    START_CODON_WEIGHTS,
+    START_SELECTION_WEIGHTS,
+    STOP_CODONS,
+    TEST_GENOMES,
+    get_genome_by_accession,
+    get_genome_by_id,
+    list_genomes_by_group,
+)
+
+# ---------------------------------------------------------------------------
+# GENOME_CATALOG integrity
+# ---------------------------------------------------------------------------
+
+EXPECTED_GROUPS = {"Proteobacteria", "Firmicutes", "Actinobacteria", "Archaea"}
+REQUIRED_KEYS = {"id", "accession", "name", "group"}
+
+
+class TestGenomeCatalogIntegrity:
+    def test_catalog_has_100_entries(self):
+        assert len(GENOME_CATALOG) == 100
+
+    def test_every_entry_has_required_keys(self):
+        for genome in GENOME_CATALOG:
+            missing = REQUIRED_KEYS - set(genome.keys())
+            assert not missing, f"Entry {genome} missing keys: {missing}"
+
+    def test_ids_are_unique(self):
+        ids = [g["id"] for g in GENOME_CATALOG]
+        assert len(ids) == len(set(ids)), "Duplicate IDs in GENOME_CATALOG"
+
+    def test_ids_run_1_to_100(self):
+        ids = sorted(g["id"] for g in GENOME_CATALOG)
+        assert ids == list(range(1, 101))
+
+    def test_all_groups_are_known(self):
+        groups = {g["group"] for g in GENOME_CATALOG}
+        assert groups == EXPECTED_GROUPS
+
+    def test_accessions_are_non_empty_strings(self):
+        for genome in GENOME_CATALOG:
+            assert isinstance(genome["accession"], str) and genome["accession"].strip()
+
+    def test_names_are_non_empty_strings(self):
+        for genome in GENOME_CATALOG:
+            assert isinstance(genome["name"], str) and genome["name"].strip()
+
+
+# ---------------------------------------------------------------------------
+# TEST_GENOMES
+# ---------------------------------------------------------------------------
+
+
+class TestTestGenomes:
+    def test_has_15_entries(self):
+        assert len(TEST_GENOMES) == 15
+
+    def test_no_duplicates(self):
+        assert len(TEST_GENOMES) == len(set(TEST_GENOMES))
+
+    def test_contains_bacteria_and_archaea(self):
+        catalog_map = {g["accession"]: g["group"] for g in GENOME_CATALOG}
+        groups = {catalog_map[acc] for acc in TEST_GENOMES if acc in catalog_map}
+        assert "Archaea" in groups
+        assert groups & {"Proteobacteria", "Firmicutes", "Actinobacteria"}
+
+
+# ---------------------------------------------------------------------------
+# get_genome_by_id()
+# ---------------------------------------------------------------------------
+
+
+class TestGetGenomeById:
+    def test_returns_correct_entry_for_id_1(self):
+        result = get_genome_by_id(1)
+        assert result is not None
+        assert result["id"] == 1
+
+    def test_returns_none_for_missing_id(self):
+        assert get_genome_by_id(999) is None
+
+    def test_returns_none_for_id_zero(self):
+        assert get_genome_by_id(0) is None
+
+    def test_all_valid_ids_return_entries(self):
+        for i in range(1, 101):
+            assert get_genome_by_id(i) is not None
+
+
+# ---------------------------------------------------------------------------
+# get_genome_by_accession()
+# ---------------------------------------------------------------------------
+
+
+class TestGetGenomeByAccession:
+    def test_returns_entry_for_known_accession(self):
+        result = get_genome_by_accession("NC_000913.3")
+        assert result is not None
+        assert result["accession"] == "NC_000913.3"
+
+    def test_returns_none_for_unknown_accession(self):
+        assert get_genome_by_accession("NC_FAKE_999.9") is None
+
+    def test_returns_none_for_empty_string(self):
+        assert get_genome_by_accession("") is None
+
+    def test_match_is_exact_not_prefix(self):
+        # "NC_000913" should not match "NC_000913.3"
+        assert get_genome_by_accession("NC_000913") is None
+
+
+# ---------------------------------------------------------------------------
+# list_genomes_by_group()
+# ---------------------------------------------------------------------------
+
+
+class TestListGenomesByGroup:
+    def test_no_filter_returns_full_catalog(self):
+        assert list_genomes_by_group() is GENOME_CATALOG
+
+    def test_proteobacteria_group(self):
+        result = list_genomes_by_group("Proteobacteria")
+        assert len(result) == 25
+        assert all(g["group"] == "Proteobacteria" for g in result)
+
+    def test_firmicutes_group(self):
+        result = list_genomes_by_group("Firmicutes")
+        assert len(result) == 25
+        assert all(g["group"] == "Firmicutes" for g in result)
+
+    def test_actinobacteria_group(self):
+        result = list_genomes_by_group("Actinobacteria")
+        assert len(result) == 25
+        assert all(g["group"] == "Actinobacteria" for g in result)
+
+    def test_archaea_group(self):
+        result = list_genomes_by_group("Archaea")
+        assert len(result) == 25
+        assert all(g["group"] == "Archaea" for g in result)
+
+    def test_unknown_group_returns_empty(self):
+        assert list_genomes_by_group("Viruses") == []
+
+
+# ---------------------------------------------------------------------------
+# Scoring constants sanity checks
+# ---------------------------------------------------------------------------
+
+
+class TestScoringConstants:
+    def test_score_weights_all_positive(self):
+        for key, val in SCORE_WEIGHTS.items():
+            assert val > 0, f"SCORE_WEIGHTS[{key!r}] is not positive"
+
+    def test_start_codon_weights_atg_is_highest(self):
+        assert START_CODON_WEIGHTS["ATG"] >= START_CODON_WEIGHTS["GTG"]
+        assert START_CODON_WEIGHTS["GTG"] >= START_CODON_WEIGHTS["TTG"]
+
+    def test_start_selection_weights_all_positive(self):
+        for key, val in START_SELECTION_WEIGHTS.items():
+            assert val > 0, f"START_SELECTION_WEIGHTS[{key!r}] is not positive"
+
+    def test_start_codons_set(self):
+        assert START_CODONS == {"ATG", "GTG", "TTG"}
+
+    def test_stop_codons_set(self):
+        assert STOP_CODONS == {"TAA", "TAG", "TGA"}
+
+    def test_min_orf_length_positive(self):
+        assert MIN_ORF_LENGTH > 0
+
+    def test_known_rbs_motifs_non_empty(self):
+        assert len(KNOWN_RBS_MOTIFS) > 0
+        assert all(isinstance(m, str) for m in KNOWN_RBS_MOTIFS)
+
+    def test_filter_thresholds_have_required_keys(self):
+        required = {"codon_threshold", "imm_threshold", "length_threshold", "combined_threshold"}
+        assert required <= set(FIRST_FILTER_THRESHOLD.keys())
+        assert required <= set(SECOND_FILTER_THRESHOLD.keys())


### PR DESCRIPTION
## Summary

Adds `tests/test_config.py` with 32 unit tests covering `src/config.py`.

**Test classes:**
- `TestGenomeCatalogIntegrity` — 100 entries, unique sequential IDs 1-100, required keys, four expected groups, non-empty accessions and names
- `TestTestGenomes` — 15 entries, no duplicates, both bacteria and archaea present
- `TestGetGenomeById` — correct lookup, `None` on missing/zero ID, all 100 IDs return results
- `TestGetGenomeByAccession` — correct lookup, `None` on unknown/empty/prefix-only input
- `TestListGenomesByGroup` — full catalog returned with no filter, 25 per group, empty list for unknown group
- `TestScoringConstants` — all weight dicts are positive, ATG ≥ GTG ≥ TTG, correct codon sets, filter threshold keys

**Side finding:** `NC_000915.1` (*H. pylori*) appears in `TEST_GENOMES` but not in `GENOME_CATALOG`. This is not a blocking bug but may warrant adding it to the catalog in a follow-up.

## Test plan

- [ ] `pytest tests/test_config.py -v` — 32 passed

Closes #33