### PR TITLE
TST: 27 async unit tests for FastAPI backend

### DIFF
--- a/doc/whatsnew/v1.0.0.rst
+++ b/doc/whatsnew/v1.0.0.rst
@@ -109,6 +109,7 @@ Test suite
 - Added ``tests/conftest.py`` — shared fixtures: ``synthetic_orf``, ``synthetic_candidate``, ``single_orf_group``, ``two_orf_group`` with documented ground-truth constants (:issue:`47`)
 - Added ``tests/test_ml_models.py`` — 32 unit and regression tests for :class:`OrfGroupClassifier` and :class:`HybridGeneFilter` covering feature extraction, feature count, edge cases, and static helpers (:issue:`47`)
 - Added ``tests/test_traditional_methods.py`` — 49 unit tests for the core bioinformatics layer in ``src/traditional_methods.py``: ORF detection on both strands, RBS scoring, codon model building, codon bias ratio, Interpolated Markov Model construction and scoring, score normalization, and combined score calculation (:issue:`14`)
+- Added ``tests/test_api.py`` — 27 async unit tests for the FastAPI backend using ``httpx.ASGITransport``; covers ``GET /``, ``GET /health``, ``GET /catalog``, ``GET /results``, ``GET /files``, request-body validation (422) for ``POST /predict`` and ``POST /predict/ncbi``, security constraints for ``POST /files/delete``, and ``POST /validate`` error handling (:issue:`28`)
 - Added ``tests/fixtures/sequences/``, ``tests/fixtures/gff/``, ``tests/fixtures/models/`` — fixture directory scaffold for future synthetic sequences, reference annotations, and mock model files (:issue:`47`)
 - Added ``tests/integration/`` — package for slow end-to-end pipeline tests (:issue:`47`)
 - Added ``.coveragerc`` — coverage configuration: measures ``src/`` and ``api/``, excludes test scaffolding and boilerplate (:issue:`66`)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for api/main.py.
+
+Uses httpx.AsyncClient with ASGITransport (httpx ≥ 0.20) to avoid the
+starlette TestClient / httpx 0.28 incompatibility.  Tests are marked
+asyncio and run via pytest-asyncio.
+
+The full prediction pipeline (POST /predict, POST /predict/ncbi) is not
+exercised here — those belong in integration tests.  These tests cover:
+- Lightweight read-only endpoints
+- Request-body validation (422 on missing required fields)
+- Security constraints on file deletion
+- 404 / error responses for missing resources
+"""
+
+import pytest
+import pytest_asyncio
+import httpx
+
+from api.main import app
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def ac():
+    """Async ASGI test client."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# GET /
+# ---------------------------------------------------------------------------
+
+
+class TestRoot:
+    async def test_returns_200(self, ac):
+        r = await ac.get("/")
+        assert r.status_code == 200
+
+    async def test_body_contains_api_name(self, ac):
+        r = await ac.get("/")
+        assert "Bacterial Gene Predictor" in r.json()["message"]
+
+    async def test_body_contains_endpoints_map(self, ac):
+        r = await ac.get("/")
+        assert "endpoints" in r.json()
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+
+class TestHealth:
+    async def test_returns_200(self, ac):
+        r = await ac.get("/health")
+        assert r.status_code == 200
+
+    async def test_status_is_healthy(self, ac):
+        r = await ac.get("/health")
+        assert r.json()["status"] == "healthy"
+
+    async def test_models_loaded_key_present(self, ac):
+        r = await ac.get("/health")
+        assert "models_loaded" in r.json()
+
+    async def test_models_loaded_is_dict(self, ac):
+        r = await ac.get("/health")
+        assert isinstance(r.json()["models_loaded"], dict)
+
+
+# ---------------------------------------------------------------------------
+# GET /catalog
+# ---------------------------------------------------------------------------
+
+
+class TestCatalog:
+    async def test_returns_200(self, ac):
+        r = await ac.get("/catalog")
+        assert r.status_code == 200
+
+    async def test_total_is_100(self, ac):
+        r = await ac.get("/catalog")
+        assert r.json()["total"] == 100
+
+    async def test_genomes_list_has_100_items(self, ac):
+        r = await ac.get("/catalog")
+        assert len(r.json()["genomes"]) == 100
+
+    async def test_each_genome_has_id_and_accession(self, ac):
+        r = await ac.get("/catalog")
+        for genome in r.json()["genomes"]:
+            assert "id" in genome
+            assert "accession" in genome
+
+
+# ---------------------------------------------------------------------------
+# GET /results
+# ---------------------------------------------------------------------------
+
+
+class TestResults:
+    async def test_returns_200(self, ac):
+        r = await ac.get("/results")
+        assert r.status_code == 200
+
+    async def test_body_has_results_key(self, ac):
+        r = await ac.get("/results")
+        assert "results" in r.json()
+
+    async def test_results_is_a_list(self, ac):
+        r = await ac.get("/results")
+        assert isinstance(r.json()["results"], list)
+
+
+# ---------------------------------------------------------------------------
+# POST /predict — request body validation only
+# ---------------------------------------------------------------------------
+
+
+class TestPredictValidation:
+    async def test_empty_body_returns_422(self, ac):
+        r = await ac.post("/predict", json={})
+        assert r.status_code == 422
+
+    async def test_missing_sequence_returns_422(self, ac):
+        r = await ac.post("/predict", json={"use_group_ml": False})
+        assert r.status_code == 422
+
+    async def test_non_json_body_returns_422(self, ac):
+        r = await ac.post("/predict", content=b"not json",
+                          headers={"Content-Type": "application/json"})
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /predict/ncbi — request body validation only
+# ---------------------------------------------------------------------------
+
+
+class TestPredictNcbiValidation:
+    async def test_empty_body_returns_422(self, ac):
+        r = await ac.post("/predict/ncbi", json={})
+        assert r.status_code == 422
+
+    async def test_missing_accession_returns_422(self, ac):
+        r = await ac.post("/predict/ncbi", json={"use_group_ml": False})
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /validate — request validation and missing-file error
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    async def test_empty_body_returns_422(self, ac):
+        r = await ac.post("/validate", json={})
+        assert r.status_code == 422
+
+    async def test_nonexistent_genome_returns_404_or_500(self, ac):
+        r = await ac.post("/validate", json={"genome_id": "NC_NONEXISTENT_FAKE"})
+        assert r.status_code in (404, 500)
+
+
+# ---------------------------------------------------------------------------
+# POST /files/delete — security constraint
+# ---------------------------------------------------------------------------
+
+
+class TestFilesDelete:
+    async def test_delete_outside_allowed_dirs_is_rejected(self, ac):
+        r = await ac.post("/files/delete", json={"paths": ["src/config.py"]})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["failed"] == 1
+        assert body["deleted"] == 0
+        assert any("Outside allowed directories" in e for e in body["errors"])
+
+    async def test_delete_nonexistent_results_file_counts_as_failed(self, ac):
+        r = await ac.post(
+            "/files/delete",
+            json={"paths": ["results/NC_FAKE_NONEXISTENT_predictions.gff"]},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["failed"] == 1
+        assert body["deleted"] == 0
+
+    async def test_empty_paths_list_returns_zero_counts(self, ac):
+        r = await ac.post("/files/delete", json={"paths": []})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["deleted"] == 0
+        assert body["failed"] == 0
+
+    async def test_missing_paths_key_returns_422(self, ac):
+        r = await ac.post("/files/delete", json={})
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /files
+# ---------------------------------------------------------------------------
+
+
+class TestFiles:
+    async def test_returns_200(self, ac):
+        r = await ac.get("/files")
+        assert r.status_code == 200
+
+    async def test_body_is_dict(self, ac):
+        r = await ac.get("/files")
+        assert isinstance(r.json(), dict)


### PR DESCRIPTION
## Summary

- Adds `tests/test_api.py` with 27 async unit tests covering all lightweight FastAPI endpoints
- Uses `httpx.ASGITransport` + `httpx.AsyncClient` to work around the starlette 0.27 / httpx 0.28 `TestClient` incompatibility
- Async fixture uses `@pytest_asyncio.fixture`; module-level `pytestmark = pytest.mark.asyncio` marks all test methods

## Endpoints covered

| Class | Endpoint | Tests |
|---|---|---|
| `TestRoot` | `GET /` | 200 status, message content, endpoints map |
| `TestHealth` | `GET /health` | 200 status, `status == "healthy"`, `models_loaded` key and type |
| `TestCatalog` | `GET /catalog` | 200 status, 100 total, 100 genomes, id+accession keys |
| `TestResults` | `GET /results` | 200 status, `results` key, list type |
| `TestPredictValidation` | `POST /predict` | 422 on empty body, missing sequence, non-JSON |
| `TestPredictNcbiValidation` | `POST /predict/ncbi` | 422 on empty body, missing accession |
| `TestValidate` | `POST /validate` | 422 on empty body, 404/500 on nonexistent genome |
| `TestFilesDelete` | `POST /files/delete` | path-traversal rejection, nonexistent file, empty list, missing key 422 |
| `TestFiles` | `GET /files` | 200 status, dict response |

## Test plan

- [x] All 27 tests pass locally
- [x] Changelog entry added to `doc/whatsnew/v1.0.0.rst`

Closes #28