### PR TITLE
PERF: Numba JIT codon bias + shared encoding — ~68× total scoring speedup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,10 @@ repos:
         name: black
         language: system
         entry: black
-        args: [--line-length=100]
         types: [python]
 
       - id: isort
         name: isort
         language: system
         entry: isort
-        args: [--profile=black, --line-length=100]
         types: [python]

--- a/api/main.py
+++ b/api/main.py
@@ -211,9 +211,7 @@ async def predict_genes_from_file(
                 )
             )
 
-        sequence_length = (
-            max(p.end for p in gene_predictions) if gene_predictions else 0
-        )
+        sequence_length = max(p.end for p in gene_predictions) if gene_predictions else 0
         genome_id = Path(file.filename).stem
 
         return PredictionResponse(
@@ -275,9 +273,7 @@ async def predict_ncbi(request: NcbiPredictionRequest):
                 )
             )
 
-        sequence_length = (
-            max(p.end for p in gene_predictions) if gene_predictions else 0
-        )
+        sequence_length = max(p.end for p in gene_predictions) if gene_predictions else 0
 
         return PredictionResponse(
             genome_id=request.accession,
@@ -372,8 +368,7 @@ async def validate_predictions(request: ValidationRequest):
             version = 2
             while True:
                 versioned_path = (
-                    results_dir
-                    / f"{request.genome_id}_validation_report_v{version}.txt"
+                    results_dir / f"{request.genome_id}_validation_report_v{version}.txt"
                 )
                 if not versioned_path.exists():
                     report_path = versioned_path
@@ -526,9 +521,7 @@ async def delete_files(request: DeleteFilesRequest):
                     str(file_path).startswith(str(project_root / "data"))
                     or str(file_path).startswith(str(project_root / "results"))
                 ):
-                    errors.append(
-                        f"Cannot delete {path_str}: Outside allowed directories"
-                    )
+                    errors.append(f"Cannot delete {path_str}: Outside allowed directories")
                     failed += 1
                     continue
 

--- a/api/models.py
+++ b/api/models.py
@@ -10,9 +10,7 @@ from pydantic import BaseModel, Field
 class PredictionRequest(BaseModel):
     """Request body for gene prediction"""
 
-    sequence: str = Field(
-        ..., description="Genome sequence in FASTA format or raw DNA sequence"
-    )
+    sequence: str = Field(..., description="Genome sequence in FASTA format or raw DNA sequence")
     filename: Optional[str] = Field(
         None, description="Optional filename for output (without extension)"
     )

--- a/doc/whatsnew/v1.0.0.rst
+++ b/doc/whatsnew/v1.0.0.rst
@@ -21,9 +21,12 @@ Enhancements
 - Added ``predict_rbs_simple()`` — scores Shine-Dalgarno signal strength in the -20 to -5 window upstream of each candidate start site
 - Added ``build_codon_model()`` and ``score_codon_bias_ratio()`` — log-odds codon usage scoring against a self-trained genome-specific model
 - Added ``build_interpolated_markov_model()`` and ``score_imm_ratio()`` — Interpolated Markov Model scoring trained on the target genome (orders 1–3)
-- Added ``score_all_orfs()`` — unified scoring combining codon bias, IMM, RBS, length, and start codon type into a ``combined_score``; uses pre-baked log tables (:func:`build_flat_log_table`) when available for a 2.2× IMM speedup (:issue:`82`)
+- Added ``score_all_orfs()`` — unified scoring combining codon bias, IMM, RBS, length, and start codon type into a ``combined_score``; Numba JIT + pre-baked tables give a **~68× end-to-end speedup** (95 s → 1.4 s for 176 K ORFs); sensitivity and precision unchanged (:issue:`82`, :issue:`84`)
 - Added ``build_flat_log_table()`` — pre-bakes ``{context+nucleotide → log_prob}`` lookup tables from a trained IMM model at build time, eliminating ``math.log()``, ``max(EPSILON)``, and ``lru_cache`` overhead during per-nucleotide scoring (:issue:`82`)
-- Added ``_score_imm_fast()`` — fast IMM log-likelihood ratio using pre-baked tables; numerically identical to ``score_imm_ratio()`` (max delta 0.00e+00 across 166K real ORFs), 2.2× faster cold and 2.4× faster warm (:issue:`82`)
+- Added ``_score_imm_numba()`` / ``_score_codon_bias_numba()`` — ``@numba.njit(cache=True)`` JIT-compiled IMM and codon-bias inner loops; 48× and 178× faster than the Python paths respectively (:issue:`84`)
+- Added ``_seq_to_int_fast()`` — vectorised DNA→int32 encoder using a pre-built ASCII lookup table; encodes 176 K ORFs in 0.45 s; shared between IMM and codon scoring to avoid double encoding (:issue:`84`)
+- Added ``build_codon_log_ratio_table()`` — 64-entry numpy array of pre-computed ``log(coding/background)`` ratios indexed by base-4 codon encoding; eliminates all ``math.log()`` calls during codon bias scoring (:issue:`84`)
+- Added ``build_numba_log_table()`` and ``build_flat_log_table()`` — pre-bake IMM log-probability tables at model-build time; fallback fast path for environments without numba (:issue:`82`)
 - Added ``normalize_all_orf_scores()`` — z-score normalization of all score components for downstream ML feature extraction
 - Added ``create_training_set()`` — self-training strategy selecting high-confidence ORFs from the target genome as positive examples
 - Added ``select_best_starts()`` — resolves overlapping start candidates within each ORF group using weighted scoring

--- a/hybrid_predictor.py
+++ b/hybrid_predictor.py
@@ -321,9 +321,7 @@ def validate_menu():
 
             if not ncbi_files:
                 print("[!] No NCBI prediction files found in results/")
-                print(
-                    "    Only files with NCBI accessions (NC_XXXXXX.X) can be auto-validated."
-                )
+                print("    Only files with NCBI accessions (NC_XXXXXX.X) can be auto-validated.")
                 print("    Use option [1] for manual validation.")
                 input("\nPress Enter to continue...")
                 return None
@@ -335,9 +333,7 @@ def validate_menu():
                 genome = get_genome_by_accession(genome_id)
 
                 if genome:
-                    print(
-                        f"  [{i}] {file.name:<45} ({size_kb:>6.1f} KB) - {genome['name']}"
-                    )
+                    print(f"  [{i}] {file.name:<45} ({size_kb:>6.1f} KB) - {genome['name']}")
                 else:
                     print(f"  [{i}] {file.name:<45} ({size_kb:>6.1f} KB) - {genome_id}")
 
@@ -345,9 +341,7 @@ def validate_menu():
 
             while True:
                 file_choice = (
-                    input(f"Choose file [1-{len(ncbi_files)}] or 'B' to go back: ")
-                    .strip()
-                    .upper()
+                    input(f"Choose file [1-{len(ncbi_files)}] or 'B' to go back: ").strip().upper()
                 )
 
                 if file_choice == "B":
@@ -505,9 +499,7 @@ def predict_ncbi_genome(
     try:
         # Search for the nucleotide record
         print("  Fetching sequence...")
-        handle = Entrez.efetch(
-            db="nucleotide", id=accession, rettype="fasta", retmode="text"
-        )
+        handle = Entrez.efetch(db="nucleotide", id=accession, rettype="fasta", retmode="text")
 
         # Save to file
         with open(fasta_path, "w") as f:
@@ -590,9 +582,7 @@ def predict_fasta_file(
     print(f"ML group filtering: {'Enabled' if use_ml else 'Disabled'}")
     if use_ml:
         print(f"  Group ML threshold: {ml_threshold}")
-    print(
-        f"Final ML filtration: {'Enabled' if use_final_filtration_ml else 'Disabled'}"
-    )
+    print(f"Final ML filtration: {'Enabled' if use_final_filtration_ml else 'Disabled'}")
     if use_final_filtration_ml:
         print(f"  Final ML threshold: {final_ml_threshold}")
 
@@ -696,9 +686,7 @@ def predict_fasta_file(
                     post_filter_count = len(final_predictions)
                     print(f"Candidates before hybrid ML: {pre_filter_count:,}")
                     print(f"Candidates after hybrid ML:  {post_filter_count:,}")
-                    print(
-                        f"Candidates removed:          {pre_filter_count - post_filter_count:,}"
-                    )
+                    print(f"Candidates removed:          {pre_filter_count - post_filter_count:,}")
                 else:
                     print(
                         f"[!] Hybrid model not found at {model_path},"
@@ -771,9 +759,7 @@ Examples:
         """,
     )
 
-    parser.add_argument(
-        "input", nargs="?", help="Catalog number, NCBI accession, or FASTA file"
-    )
+    parser.add_argument("input", nargs="?", help="Catalog number, NCBI accession, or FASTA file")
     parser.add_argument("--email", help="Email for NCBI (required for downloads)")
 
     # ML filtering options
@@ -789,9 +775,7 @@ Examples:
         default=0.12,
         help="Final hybrid ML filtration threshold (default: 0.12)",
     )
-    parser.add_argument(
-        "--no-group-ml", action="store_true", help="Disable ML group filtering"
-    )
+    parser.add_argument("--no-group-ml", action="store_true", help="Disable ML group filtering")
     parser.add_argument(
         "--no-final-ml", action="store_true", help="Disable final hybrid ML filtration"
     )
@@ -804,9 +788,7 @@ Examples:
         choices=["Proteobacteria", "Firmicutes", "Actinobacteria", "Archaea"],
         help="Filter list by taxonomic group",
     )
-    parser.add_argument(
-        "-i", "--interactive", action="store_true", help="Force interactive mode"
-    )
+    parser.add_argument("-i", "--interactive", action="store_true", help="Force interactive mode")
 
     args = parser.parse_args()
 
@@ -821,9 +803,7 @@ Examples:
             print(f"\nShowing: {args.group} ({len(genomes)} genomes)")
         else:
             genomes = GENOME_CATALOG
-            print(
-                "\nUse --group to filter by: Proteobacteria, Firmicutes, Actinobacteria, Archaea"
-            )
+            print("\nUse --group to filter by: Proteobacteria, Firmicutes, Actinobacteria, Archaea")
 
         print()
         current_group = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
+[tool.black]
+line-length = 100
+target-version = ["py39", "py310", "py311"]
+
 [tool.isort]
 profile = "black"
-
-[tool.black]
-target-version = ["py39", "py310", "py311"]
+line_length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ joblib>=1.2.0
 scikit-learn>=1.0.0
 lightgbm>=3.3.0
 torch>=2.0.0
+numba>=0.57.0
 tqdm>=4.60.0
 
 # Web Framework

--- a/src/cache.py
+++ b/src/cache.py
@@ -117,9 +117,7 @@ def get_cached_genome(genome_id: str, cached_data: Dict = None) -> Dict:
         cached_data = load_cache()
 
     if genome_id not in cached_data:
-        raise KeyError(
-            f"Genome {genome_id} not in cache. Run precompute_genomes() first."
-        )
+        raise KeyError(f"Genome {genome_id} not in cache. Run precompute_genomes() first.")
 
     return cached_data[genome_id]
 

--- a/src/comparative_analysis.py
+++ b/src/comparative_analysis.py
@@ -111,16 +111,10 @@ def analyze_score_distributions(
         fp_max = np.max(fp_scores)
 
         # Display comparison
-        print(
-            f"{'Metric':<15} {'True Positives':>15} {'False Positives':>15} {'Difference':>15}"
-        )
+        print(f"{'Metric':<15} {'True Positives':>15} {'False Positives':>15} {'Difference':>15}")
         print(f"{'-'*15} {'-'*15} {'-'*15} {'-'*15}")
-        print(
-            f"{'Mean':<15} {tp_mean:>15.4f} {fp_mean:>15.4f} {tp_mean-fp_mean:>15.4f}"
-        )
-        print(
-            f"{'Median':<15} {tp_median:>15.4f} {fp_median:>15.4f} {tp_median-fp_median:>15.4f}"
-        )
+        print(f"{'Mean':<15} {tp_mean:>15.4f} {fp_mean:>15.4f} {tp_mean-fp_mean:>15.4f}")
+        print(f"{'Median':<15} {tp_median:>15.4f} {fp_median:>15.4f} {tp_median-fp_median:>15.4f}")
         print(f"{'Std Dev':<15} {tp_std:>15.4f} {fp_std:>15.4f} {tp_std-fp_std:>15.4f}")
         print(f"{'Min':<15} {tp_min:>15.4f} {fp_min:>15.4f} {tp_min-fp_min:>15.4f}")
         print(f"{'Max':<15} {tp_max:>15.4f} {fp_max:>15.4f} {tp_max-fp_max:>15.4f}")
@@ -177,9 +171,7 @@ def analyze_score_distributions(
                 f"{'Metric':<15} {'True Positives':>15} {'False Positives':>15} {'Difference':>15}"
             )
             print(f"{'-'*15} {'-'*15} {'-'*15} {'-'*15}")
-            print(
-                f"{'Mean':<15} {tp_mean:>15.4f} {fp_mean:>15.4f} {tp_mean-fp_mean:>15.4f}"
-            )
+            print(f"{'Mean':<15} {tp_mean:>15.4f} {fp_mean:>15.4f} {tp_mean-fp_mean:>15.4f}")
             print(
                 f"{'Median':<15} {tp_median:>15.4f} {fp_median:>15.4f} {tp_median-fp_median:>15.4f}"
             )
@@ -190,12 +182,8 @@ def analyze_score_distributions(
         print("COMBINED SCORE DISTRIBUTION")
         print("=" * 80)
 
-        tp_combined = [
-            orf["combined_score"] for orf in tp_orfs if "combined_score" in orf
-        ]
-        fp_combined = [
-            orf["combined_score"] for orf in fp_orfs if "combined_score" in orf
-        ]
+        tp_combined = [orf["combined_score"] for orf in tp_orfs if "combined_score" in orf]
+        fp_combined = [orf["combined_score"] for orf in fp_orfs if "combined_score" in orf]
 
         if tp_combined and fp_combined:
             tp_mean = np.mean(tp_combined)
@@ -209,9 +197,7 @@ def analyze_score_distributions(
                 f"{'Metric':<15} {'True Positives':>15} {'False Positives':>15} {'Difference':>15}"
             )
             print(f"{'-'*15} {'-'*15} {'-'*15} {'-'*15}")
-            print(
-                f"{'Mean':<15} {tp_mean:>15.4f} {fp_mean:>15.4f} {tp_mean-fp_mean:>15.4f}"
-            )
+            print(f"{'Mean':<15} {tp_mean:>15.4f} {fp_mean:>15.4f} {tp_mean-fp_mean:>15.4f}")
             print(
                 f"{'Median':<15} {tp_median:>15.4f} {fp_median:>15.4f} {tp_median-fp_median:>15.4f}"
             )
@@ -225,9 +211,7 @@ def analyze_score_distributions(
             print(f"{'Percentile':<15} {'True Positives':>15} {'False Positives':>15}")
             print(f"{'-'*15} {'-'*15} {'-'*15}")
             for i, pct in enumerate([10, 25, 50, 75, 90]):
-                print(
-                    f"{f'{pct}th':<15} {tp_percentiles[i]:>15.4f} {fp_percentiles[i]:>15.4f}"
-                )
+                print(f"{f'{pct}th':<15} {tp_percentiles[i]:>15.4f} {fp_percentiles[i]:>15.4f}")
 
     return stats
 
@@ -237,9 +221,7 @@ def analyze_score_distributions(
 # =============================================================================
 
 
-def plot_score_distributions(
-    all_orfs: List[Dict], reference_genes: Set, genome_id: str = None
-):
+def plot_score_distributions(all_orfs: List[Dict], reference_genes: Set, genome_id: str = None):
     """Create comprehensive visualization of score distributions for TP vs FP."""
     print("Classifying ORFs...")
     tp_orfs = []
@@ -378,9 +360,7 @@ def plot_score_distributions(
                 label=f"TP (n={len(tp_scores):,})",
                 density=True,
             )
-            ax.axvline(
-                np.mean(tp_scores), color="darkgreen", linestyle="--", linewidth=2
-            )
+            ax.axvline(np.mean(tp_scores), color="darkgreen", linestyle="--", linewidth=2)
             ax.axvline(np.mean(fp_scores), color="darkred", linestyle="--", linewidth=2)
 
             ax.set_xlabel(component.replace("_", " ").title())
@@ -393,12 +373,8 @@ def plot_score_distributions(
     if "combined_score" in all_orfs[0]:
         ax = axes2[5]
 
-        tp_combined = [
-            orf["combined_score"] for orf in tp_orfs if "combined_score" in orf
-        ]
-        fp_combined = [
-            orf["combined_score"] for orf in fp_orfs if "combined_score" in orf
-        ]
+        tp_combined = [orf["combined_score"] for orf in tp_orfs if "combined_score" in orf]
+        fp_combined = [orf["combined_score"] for orf in fp_orfs if "combined_score" in orf]
 
         if tp_combined and fp_combined:
             ax.hist(
@@ -467,9 +443,7 @@ def plot_score_distributions(
 # =============================================================================
 
 
-def compare_orfs_to_reference(
-    orfs: List[Dict], genome_id: str, cached_data: Dict = None
-) -> Dict:
+def compare_orfs_to_reference(orfs: List[Dict], genome_id: str, cached_data: Dict = None) -> Dict:
     """Compare predicted ORFs to reference CDS using GFF file."""
     # Get GFF path
     gff_path = get_gff_path(genome_id)
@@ -585,9 +559,7 @@ def compare_results_file_to_reference(genome_id: str) -> Dict:
         reference_gff = get_gff_path(genome_id)
 
         if reference_gff is None or not Path(reference_gff).exists():
-            print(
-                "  Reference GFF not found locally, attempting to download from NCBI..."
-            )
+            print("  Reference GFF not found locally, attempting to download from NCBI...")
 
             # Set up download path
             full_dataset_dir = Path("data") / "full_dataset"
@@ -750,9 +722,7 @@ def analyze_non_cds_genes(gff_path):
     print(f"\nTotal genes in annotation: {len(all_genes):,}")
     pct_coding = protein_coding / len(all_genes) * 100
     pct_noncoding = non_coding / len(all_genes) * 100
-    print(
-        f"  • Protein-coding genes (with CDS): {protein_coding:,} ({pct_coding:.1f}%)"
-    )
+    print(f"  • Protein-coding genes (with CDS): {protein_coding:,} ({pct_coding:.1f}%)")
     print(f"  • Non-coding genes (RNA, etc.): {non_coding:,} ({pct_noncoding:.1f}%)")
 
     print("\n INTERPRETATION:")
@@ -862,9 +832,7 @@ def compare_codon_usage(
     print("=" * 80)
     print(f"Total codons analyzed: {len(all_codons)}")
     print(f"Average coding frequency: {sum(coding_freqs)/len(coding_freqs):.6f}")
-    print(
-        f"Average background frequency: {sum(background_freqs)/len(background_freqs):.6f}"
-    )
+    print(f"Average background frequency: {sum(background_freqs)/len(background_freqs):.6f}")
 
     # Find codons with biggest differences
     codon_diffs = list(zip(all_codons, differences))

--- a/src/data_management.py
+++ b/src/data_management.py
@@ -85,9 +85,7 @@ def download_genome_and_reference(
     else:
         print(f"Downloading genome {genome_id}...")
         try:
-            handle = Entrez.efetch(
-                db="nuccore", id=genome_id, rettype="fasta", retmode="text"
-            )
+            handle = Entrez.efetch(db="nuccore", id=genome_id, rettype="fasta", retmode="text")
             genome_record = SeqIO.read(handle, "fasta")
             handle.close()
 
@@ -105,9 +103,7 @@ def download_genome_and_reference(
     else:
         print("Downloading reference GFF...")
         try:
-            handle = Entrez.efetch(
-                db="nuccore", id=genome_id, rettype="gff3", retmode="text"
-            )
+            handle = Entrez.efetch(db="nuccore", id=genome_id, rettype="gff3", retmode="text")
             with open(gff_path, "w") as f:
                 f.write(handle.read())
             handle.close()
@@ -271,9 +267,7 @@ def download_all_test_genomes(
         print(f"\n[{i}/{len(TEST_GENOMES)}] Processing: {genome_id}")
         print("-" * 60)
 
-        fasta_path, gff_path = download_genome_and_reference(
-            genome_id, output_dir, email
-        )
+        fasta_path, gff_path = download_genome_and_reference(genome_id, output_dir, email)
 
         if fasta_path and gff_path:
             results[genome_id] = {"fasta": fasta_path, "gff": gff_path}

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -131,17 +131,13 @@ class OrfGroupClassifier:
                 "combined_max": max(combined_scores),
                 "combined_mean": np.mean(combined_scores),
                 "combined_std": np.std(combined_scores),
-                "combined_entropy": self._entropy_from_probs(
-                    np.maximum(combined_scores, 0)
-                ),
+                "combined_entropy": self._entropy_from_probs(np.maximum(combined_scores, 0)),
                 "combined_margin_top2": (
                     np.sort(combined_scores)[-1] - np.sort(combined_scores)[-2]
                     if len(combined_scores) > 1
                     else combined_scores[0]
                 ),
-                "frac_top_orfs": np.sum(
-                    np.array(combined_scores) >= 0.8 * max(combined_scores)
-                )
+                "frac_top_orfs": np.sum(np.array(combined_scores) >= 0.8 * max(combined_scores))
                 / len(combined_scores),
                 "rbs_max": max(rbs_scores),
                 "rbs_mean": np.mean(rbs_scores),
@@ -164,15 +160,12 @@ class OrfGroupClassifier:
             max_start = max(start_scores)
             max_start_select = max(start_select_scores)
 
-            rel_combined = [
-                c / max_combined if max_combined > 0 else 0 for c in combined_scores
-            ]
+            rel_combined = [c / max_combined if max_combined > 0 else 0 for c in combined_scores]
             rel_rbs = [c / max_rbs if max_rbs > 0 else 0 for c in rbs_scores]
             rel_codon = [c / max_codon if max_codon > 0 else 0 for c in codon_scores]
             rel_start = [c / max_start if max_start > 0 else 0 for c in start_scores]
             rel_start_select = [
-                c / max_start_select if max_start_select > 0 else 0
-                for c in start_select_scores
+                c / max_start_select if max_start_select > 0 else 0 for c in start_select_scores
             ]
 
             group_features.update(
@@ -187,9 +180,7 @@ class OrfGroupClassifier:
                     "rel_start_max": np.max(rel_start),
                     "rel_start_select_mean": np.mean(rel_start_select),
                     "rel_start_select_max": np.max(rel_start_select),
-                    "frac_top_combined": np.sum(
-                        np.array(combined_scores) >= 0.95 * max_combined
-                    )
+                    "frac_top_combined": np.sum(np.array(combined_scores) >= 0.95 * max_combined)
                     / len(combined_scores),
                     "frac_top_start_select": np.sum(
                         np.array(start_select_scores) >= 0.95 * max_start_select
@@ -273,9 +264,7 @@ class OrfGroupClassifier:
         )
 
         # Filter groups
-        filtered_groups = {
-            gid: orfs for gid, orfs in groups.items() if gid in kept_group_ids
-        }
+        filtered_groups = {gid: orfs for gid, orfs in groups.items() if gid in kept_group_ids}
 
         return filtered_groups
 
@@ -398,9 +387,7 @@ class HybridGeneFilter:
         with open(model_path, "rb") as f:
             data = pickle.load(f)
 
-        model = HybridGenePredictor(
-            num_traditional_features=data["num_traditional_features"]
-        )
+        model = HybridGenePredictor(num_traditional_features=data["num_traditional_features"])
         model.load_state_dict(data["model_state_dict"])
         model.eval()
 
@@ -496,9 +483,7 @@ class HybridGeneFilter:
             hydro_values = [kd_scale.get(aa, 0.0) for aa in protein]
             return {
                 "hydro_mean": float(np.mean(hydro_values)) if hydro_values else 0.0,
-                "hydro_std": (
-                    float(np.std(hydro_values)) if len(hydro_values) > 1 else 0.0
-                ),
+                "hydro_std": (float(np.std(hydro_values)) if len(hydro_values) > 1 else 0.0),
                 "charge_mean": float(charge_mean),
                 "aromatic_frac": float(aromatic_frac),
                 "small_frac": float(small_frac),
@@ -514,9 +499,7 @@ class HybridGeneFilter:
                 polar_frac=0.0,
             )
 
-    def extract_features(
-        self, candidates: List[Dict], genome_id: str = "unknown"
-    ) -> pd.DataFrame:
+    def extract_features(self, candidates: List[Dict], genome_id: str = "unknown") -> pd.DataFrame:
         rows = []
         for candidate in candidates:
             sequence = candidate.get("sequence", "").upper()
@@ -553,9 +536,7 @@ class HybridGeneFilter:
             feature_dict["purine_content"] = (a + g) / seq_len if seq_len > 0 else 0.0
             feature_dict["effective_num_codons"] = self._calculate_enc(sequence)
             feature_dict["codon_bias_index"] = self._calculate_cbi(sequence)
-            feature_dict["has_hairpin_near_stop"] = self._detect_hairpin_near_stop(
-                sequence
-            )
+            feature_dict["has_hairpin_near_stop"] = self._detect_hairpin_near_stop(sequence)
             aa_props = self._calculate_amino_acid_properties(sequence)
             feature_dict.update(
                 {
@@ -618,9 +599,7 @@ class HybridGeneFilter:
         X_features = torch.tensor(df[self.feature_names].values, dtype=torch.float32)
 
         # Determine max sequence length
-        max_seq_len = max(
-            (len(c.get("sequence", "")) for c in candidates), default=1000
-        )
+        max_seq_len = max((len(c.get("sequence", "")) for c in candidates), default=1000)
 
         # Process in batches to avoid OOM
         all_probs = []
@@ -639,9 +618,7 @@ class HybridGeneFilter:
                 batch_candidates = candidates[i:batch_end]
 
                 # One-hot encode batch
-                X_sequences_batch = self._one_hot_encode_dna(
-                    batch_candidates, max_len=max_seq_len
-                )
+                X_sequences_batch = self._one_hot_encode_dna(batch_candidates, max_len=max_seq_len)
                 X_features_batch = X_features[i:batch_end]
 
                 # Move to device
@@ -690,9 +667,7 @@ class HybridGeneFilter:
         Returns:
             Filtered list of candidates
         """
-        preds, probs, gene_ids = self.predict(
-            candidates, genome_id, threshold, batch_size
-        )
+        preds, probs, gene_ids = self.predict(candidates, genome_id, threshold, batch_size)
 
         kept = []
         for cand, p in zip(candidates, probs):

--- a/src/traditional_methods.py
+++ b/src/traditional_methods.py
@@ -1176,7 +1176,7 @@ def build_all_scoring_models(
     numba_coding_table = numba_noncoding_table = None
     codon_log_ratio_table = None
     if _NUMBA_AVAILABLE:
-        print(f"  Building Numba integer tables...")
+        print("  Building Numba integer tables...")
         numba_coding_table = build_numba_log_table(coding_log_table, estimated_order)
         numba_noncoding_table = build_numba_log_table(noncoding_log_table, estimated_order)
         codon_log_ratio_table = build_codon_log_ratio_table(codon_model, background_codon_model)

--- a/src/traditional_methods.py
+++ b/src/traditional_methods.py
@@ -17,7 +17,7 @@ import math
 import time
 from collections import Counter, defaultdict
 from functools import lru_cache
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 
@@ -49,12 +49,12 @@ try:
                 kmer_int = kmer_int * 4 + nj
             if valid:
                 L = i - start + 1
-                offset = (4 ** L - 1) // 3
+                offset = (4**L - 1) // 3
                 idx = offset + kmer_int
-                c_total  += coding_t[i % 3, idx]
+                c_total += coding_t[i % 3, idx]
                 nc_total += noncoding_t[i % 3, idx]
             else:
-                c_total  += log_epsilon
+                c_total += log_epsilon
                 nc_total += log_epsilon
         return (c_total - nc_total) / n
 
@@ -89,6 +89,7 @@ except ImportError:
     _NUMBA_AVAILABLE = False
     _score_imm_numba = None
     _score_codon_bias_numba = None
+
 from Bio.Seq import Seq
 
 from .config import (
@@ -197,9 +198,7 @@ def _seq_to_int_fast(s: str) -> np.ndarray:
     return _ASCII_TO_INT[np.frombuffer(s.encode("ascii"), dtype=np.uint8)]
 
 
-def build_numba_log_table(
-    log_table: List[Dict[str, float]], max_order: int
-) -> np.ndarray:
+def build_numba_log_table(log_table: List[Dict[str, float]], max_order: int) -> np.ndarray:
     """Convert a flat string-keyed log table to an integer-indexed numpy array.
 
     Index layout for a k-mer of total length L (context L-1 chars + nucleotide):
@@ -212,7 +211,7 @@ def build_numba_log_table(
     _NUC = {"A": 0, "C": 1, "G": 2, "T": 3}
     total = (4 ** (max_order + 2) - 1) // 3
     n_pos = len(log_table)
-    tbl   = np.full((n_pos, total), _LOG_EPSILON, dtype=np.float64)
+    tbl = np.full((n_pos, total), _LOG_EPSILON, dtype=np.float64)
 
     for pos in range(n_pos):
         for key, val in log_table[pos].items():
@@ -247,7 +246,7 @@ def build_codon_log_ratio_table(
         if len(codon) != 3 or any(c not in _NUC for c in codon):
             continue
         a = _NUC[codon[0]] * 16 + _NUC[codon[1]] * 4 + _NUC[codon[2]]
-        c_freq  = codon_model.get(codon, 1e-4)
+        c_freq = codon_model.get(codon, 1e-4)
         bg_freq = background_codon_model.get(codon, 1e-4)
         table[a] = math.log(c_freq) - math.log(bg_freq)
     return table
@@ -1085,12 +1084,8 @@ def score_imm_ratio(
         else:
             coding_prob = get_interpolated_probability(nucleotide, context, 0, coding_id)
             noncoding_prob = get_interpolated_probability(nucleotide, context, 0, noncoding_id)
-            coding_prob = get_interpolated_probability(
-                nucleotide, context, 0, coding_id
-            )
-            noncoding_prob = get_interpolated_probability(
-                nucleotide, context, 0, noncoding_id
-            )
+            coding_prob = get_interpolated_probability(nucleotide, context, 0, coding_id)
+            noncoding_prob = get_interpolated_probability(nucleotide, context, 0, noncoding_id)
 
         coding_prob = max(coding_prob, EPSILON)
         noncoding_prob = max(noncoding_prob, EPSILON)
@@ -1182,13 +1177,18 @@ def build_all_scoring_models(
     codon_log_ratio_table = None
     if _NUMBA_AVAILABLE:
         print(f"  Building Numba integer tables...")
-        numba_coding_table    = build_numba_log_table(coding_log_table,    estimated_order)
+        numba_coding_table = build_numba_log_table(coding_log_table, estimated_order)
         numba_noncoding_table = build_numba_log_table(noncoding_log_table, estimated_order)
         codon_log_ratio_table = build_codon_log_ratio_table(codon_model, background_codon_model)
         # Warm up both JIT functions so first scoring call has no compile latency
         _warmup = np.array([0, 1, 2, 3, 0, 1, 2], dtype=np.int32)
-        _score_imm_numba(_warmup, numba_coding_table, numba_noncoding_table,
-                         estimated_order, _LOG_EPSILON)
+        _score_imm_numba(
+            _warmup,
+            numba_coding_table,
+            numba_noncoding_table,
+            estimated_order,
+            _LOG_EPSILON,
+        )
         _score_codon_bias_numba(_warmup, codon_log_ratio_table)
 
     print(f"✓ All models built in {time.time() - start_time:.1f}s")
@@ -1304,14 +1304,14 @@ def score_all_orfs(
     print(f"Scoring {len(all_orfs):,} ORFs with traditional methods...")
     start_time = time.time()
 
-    codon_model         = models["codon_model"]
+    codon_model = models["codon_model"]
     background_codon_model = models["background_codon_model"]
-    max_order           = models["max_order"]
-    numba_coding        = models.get("numba_coding_table")
-    numba_noncoding     = models.get("numba_noncoding_table")
-    codon_ratio_tbl     = models.get("codon_log_ratio_table")
-    coding_log          = models.get("coding_log_table")
-    noncoding_log       = models.get("noncoding_log_table")
+    max_order = models["max_order"]
+    numba_coding = models.get("numba_coding_table")
+    numba_noncoding = models.get("numba_noncoding_table")
+    codon_ratio_tbl = models.get("codon_log_ratio_table")
+    coding_log = models.get("coding_log_table")
+    noncoding_log = models.get("noncoding_log_table")
     use_numba = _NUMBA_AVAILABLE and numba_coding is not None and codon_ratio_tbl is not None
     if use_numba:
         assert numba_coding is not None
@@ -1326,9 +1326,15 @@ def score_all_orfs(
             # Encode once — reuse int array for both codon and IMM scoring
             seq_arr = _seq_to_int_fast(orf["sequence"])
             orf["codon_score"] = float(_score_codon_bias_numba(seq_arr, codon_ratio_tbl))
-            orf["imm_score"]   = float(_score_imm_numba(
-                seq_arr, numba_coding, numba_noncoding, max_order, _LOG_EPSILON,
-            ))
+            orf["imm_score"] = float(
+                _score_imm_numba(
+                    seq_arr,
+                    numba_coding,
+                    numba_noncoding,
+                    max_order,
+                    _LOG_EPSILON,
+                )
+            )
         else:
             # Fallback for environments where numba is not installed
             orf["codon_score"] = score_codon_bias_ratio(

--- a/src/traditional_methods.py
+++ b/src/traditional_methods.py
@@ -17,9 +17,78 @@ import math
 import time
 from collections import Counter, defaultdict
 from functools import lru_cache
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
+
+try:
+    import numba as _numba
+
+    @_numba.njit(cache=True)
+    def _score_imm_numba(
+        seq_arr: np.ndarray,
+        coding_t: np.ndarray,
+        noncoding_t: np.ndarray,
+        max_order: int,
+        log_epsilon: float,
+    ) -> float:
+        """Numba-JIT IMM scoring. seq_arr: int32 array (A=0,C=1,G=2,T=3, other=4)."""
+        n = len(seq_arr)
+        if n < 3:
+            return 0.0
+        c_total = nc_total = 0.0
+        for i in range(n):
+            start = i - max_order if i >= max_order else 0
+            kmer_int = 0
+            valid = True
+            for j in range(start, i + 1):
+                nj = seq_arr[j]
+                if nj >= 4:
+                    valid = False
+                    break
+                kmer_int = kmer_int * 4 + nj
+            if valid:
+                L = i - start + 1
+                offset = (4 ** L - 1) // 3
+                idx = offset + kmer_int
+                c_total  += coding_t[i % 3, idx]
+                nc_total += noncoding_t[i % 3, idx]
+            else:
+                c_total  += log_epsilon
+                nc_total += log_epsilon
+        return (c_total - nc_total) / n
+
+    @_numba.njit(cache=True)
+    def _score_codon_bias_numba(
+        seq_arr: np.ndarray,
+        log_ratio_table: np.ndarray,
+    ) -> float:
+        """Numba-JIT codon bias log-ratio scoring.
+
+        seq_arr        : int32 array (A=0, C=1, G=2, T=3, other=4)
+        log_ratio_table: float64 array of shape (64,) indexed by
+                         a*16 + b*4 + c  (base-4 encoding of the codon)
+        """
+        n = len(seq_arr)
+        score = 0.0
+        count = 0
+        for i in range(0, n - 2, 3):
+            a = seq_arr[i]
+            b = seq_arr[i + 1]
+            c = seq_arr[i + 2]
+            if a < 4 and b < 4 and c < 4:
+                score += log_ratio_table[a * 16 + b * 4 + c]
+                count += 1
+        if count == 0:
+            return 0.0
+        return float(score / count)
+
+    _NUMBA_AVAILABLE = True
+
+except ImportError:
+    _NUMBA_AVAILABLE = False
+    _score_imm_numba = None
+    _score_codon_bias_numba = None
 from Bio.Seq import Seq
 
 from .config import (
@@ -108,6 +177,80 @@ def _score_imm_fast(
         c_total += coding_log[pos].get(key, _LOG_EPSILON)
         nc_total += noncoding_log[pos].get(key, _LOG_EPSILON)
     return (c_total - nc_total) / n
+
+
+# Pre-built ASCII→int lookup table (length 128): A=0, C=1, G=2, T=3, other=4.
+# A single numpy fancy-index replaces four boolean scan passes.
+_ASCII_TO_INT: np.ndarray = np.full(128, 4, dtype=np.int32)
+_ASCII_TO_INT[65] = 0  # A
+_ASCII_TO_INT[67] = 1  # C
+_ASCII_TO_INT[71] = 2  # G
+_ASCII_TO_INT[84] = 3  # T
+
+
+def _seq_to_int_fast(s: str) -> np.ndarray:
+    """Vectorised DNA → int32 encoding (A=0, C=1, G=2, T=3, other=4).
+
+    Uses a pre-built ASCII lookup table — one fancy-index op per call,
+    significantly faster than four boolean-scan passes for short ORFs.
+    """
+    return _ASCII_TO_INT[np.frombuffer(s.encode("ascii"), dtype=np.uint8)]
+
+
+def build_numba_log_table(
+    log_table: List[Dict[str, float]], max_order: int
+) -> np.ndarray:
+    """Convert a flat string-keyed log table to an integer-indexed numpy array.
+
+    Index layout for a k-mer of total length L (context L-1 chars + nucleotide):
+        offset(L) = (4^L - 1) // 3   (cumulative count of shorter k-mers)
+        index     = offset(L) + base4_integer_encoding(k-mer)
+
+    Array shape: (n_positions, (4^(max_order+2) - 1) // 3)
+    Typically shape (3, 87381) for max_order=7 — ~4 MB for the pair.
+    """
+    _NUC = {"A": 0, "C": 1, "G": 2, "T": 3}
+    total = (4 ** (max_order + 2) - 1) // 3
+    n_pos = len(log_table)
+    tbl   = np.full((n_pos, total), _LOG_EPSILON, dtype=np.float64)
+
+    for pos in range(n_pos):
+        for key, val in log_table[pos].items():
+            idx, valid = 0, True
+            for ch in key:
+                ni = _NUC.get(ch, -1)
+                if ni == -1:
+                    valid = False
+                    break
+                idx = idx * 4 + ni
+            if valid:
+                offset = (4 ** len(key) - 1) // 3
+                tbl[pos, offset + idx] = val
+
+    return tbl
+
+
+def build_codon_log_ratio_table(
+    codon_model: Dict[str, float],
+    background_codon_model: Dict[str, float],
+) -> np.ndarray:
+    """Build a 64-entry log-ratio table for Numba codon bias scoring.
+
+    Index = a*16 + b*4 + c  (base-4 encoding, A=0 C=1 G=2 T=3).
+    Value = log(coding_freq) - log(background_freq).
+    Codons absent from either model default to 0.0 (neutral).
+    """
+    _NUC = {"A": 0, "C": 1, "G": 2, "T": 3}
+    table = np.zeros(64, dtype=np.float64)
+    all_codons = set(codon_model) | set(background_codon_model)
+    for codon in all_codons:
+        if len(codon) != 3 or any(c not in _NUC for c in codon):
+            continue
+        a = _NUC[codon[0]] * 16 + _NUC[codon[1]] * 4 + _NUC[codon[2]]
+        c_freq  = codon_model.get(codon, 1e-4)
+        bg_freq = background_codon_model.get(codon, 1e-4)
+        table[a] = math.log(c_freq) - math.log(bg_freq)
+    return table
 
 
 # =============================================================================
@@ -1035,8 +1178,22 @@ def build_all_scoring_models(
     coding_log_table = build_flat_log_table(coding_imm, estimated_order)
     noncoding_log_table = build_flat_log_table(noncoding_imm, estimated_order)
 
+    numba_coding_table = numba_noncoding_table = None
+    codon_log_ratio_table = None
+    if _NUMBA_AVAILABLE:
+        print(f"  Building Numba integer tables...")
+        numba_coding_table    = build_numba_log_table(coding_log_table,    estimated_order)
+        numba_noncoding_table = build_numba_log_table(noncoding_log_table, estimated_order)
+        codon_log_ratio_table = build_codon_log_ratio_table(codon_model, background_codon_model)
+        # Warm up both JIT functions so first scoring call has no compile latency
+        _warmup = np.array([0, 1, 2, 3, 0, 1, 2], dtype=np.int32)
+        _score_imm_numba(_warmup, numba_coding_table, numba_noncoding_table,
+                         estimated_order, _LOG_EPSILON)
+        _score_codon_bias_numba(_warmup, codon_log_ratio_table)
+
     print(f"✓ All models built in {time.time() - start_time:.1f}s")
     print(f"  IMM order: {estimated_order}")
+    print(f"  IMM backend: {'numba' if _NUMBA_AVAILABLE else 'python'}")
     print(f"  Training sequences: {len(training_seqs)} ({n_training:,} bp)")
     print(f"  Intergenic sequences: {len(intergenic_seqs)} ({n_intergenic:,} bp)")
 
@@ -1048,6 +1205,9 @@ def build_all_scoring_models(
         "max_order": estimated_order,
         "coding_log_table": coding_log_table,
         "noncoding_log_table": noncoding_log_table,
+        "numba_coding_table": numba_coding_table,
+        "numba_noncoding_table": numba_noncoding_table,
+        "codon_log_ratio_table": codon_log_ratio_table,
     }
 
 
@@ -1144,30 +1304,38 @@ def score_all_orfs(
     print(f"Scoring {len(all_orfs):,} ORFs with traditional methods...")
     start_time = time.time()
 
-    codon_model = models["codon_model"]
+    codon_model         = models["codon_model"]
     background_codon_model = models["background_codon_model"]
-    coding_imm = models["coding_imm"]
-    noncoding_imm = models["noncoding_imm"]
-    max_order = models["max_order"]
-    coding_log = models.get("coding_log_table")
-    noncoding_log = models.get("noncoding_log_table")
-    use_fast_imm = coding_log is not None and noncoding_log is not None
+    max_order           = models["max_order"]
+    numba_coding        = models.get("numba_coding_table")
+    numba_noncoding     = models.get("numba_noncoding_table")
+    codon_ratio_tbl     = models.get("codon_log_ratio_table")
+    coding_log          = models.get("coding_log_table")
+    noncoding_log       = models.get("noncoding_log_table")
+    use_numba = _NUMBA_AVAILABLE and numba_coding is not None and codon_ratio_tbl is not None
+    if use_numba:
+        assert numba_coding is not None
+        assert numba_noncoding is not None
+        assert codon_ratio_tbl is not None
 
     for i, orf in enumerate(all_orfs):
         if i % 25000 == 0 and i > 0:
             print(f"  {i:,}...")
 
-        orf["codon_score"] = score_codon_bias_ratio(
-            orf["sequence"], codon_model, background_codon_model
-        )
-
-        if use_fast_imm:
+        if use_numba:
+            # Encode once — reuse int array for both codon and IMM scoring
+            seq_arr = _seq_to_int_fast(orf["sequence"])
+            orf["codon_score"] = float(_score_codon_bias_numba(seq_arr, codon_ratio_tbl))
+            orf["imm_score"]   = float(_score_imm_numba(
+                seq_arr, numba_coding, numba_noncoding, max_order, _LOG_EPSILON,
+            ))
+        else:
+            # Fallback for environments where numba is not installed
+            orf["codon_score"] = score_codon_bias_ratio(
+                orf["sequence"], codon_model, background_codon_model
+            )
             orf["imm_score"] = _score_imm_fast(
                 orf["sequence"], coding_log, noncoding_log, max_order
-            )
-        else:
-            orf["imm_score"] = score_imm_ratio(
-                orf["sequence"], coding_imm, noncoding_imm, max_order
             )
 
         if "rbs_score" not in orf:

--- a/src/validation.py
+++ b/src/validation.py
@@ -14,9 +14,7 @@ from pathlib import Path
 from typing import Dict
 
 
-def validate_predictions(
-    pred_path: str, ref_path: str = None, genome_id: str = None
-) -> Dict:
+def validate_predictions(pred_path: str, ref_path: str = None, genome_id: str = None) -> Dict:
     """
     Validate predictions against reference annotations.
 

--- a/tests/test_traditional_methods.py
+++ b/tests/test_traditional_methods.py
@@ -18,12 +18,17 @@ import pytest
 import math
 
 from src.traditional_methods import (
+    _ASCII_TO_INT,
     _LOG_EPSILON,
+    _NUMBA_AVAILABLE,
     _score_imm_fast,
+    _seq_to_int_fast,
     add_combined_scores,
+    build_codon_log_ratio_table,
     build_codon_model,
     build_flat_log_table,
     build_interpolated_markov_model,
+    build_numba_log_table,
     clear_imm_cache,
     find_orfs_candidates,
     normalize_all_orf_scores,
@@ -578,6 +583,264 @@ class TestScoreImmFast:
         result = _score_imm_fast("ATGNNNNTAA" * 5, c_log, nc_log, self._MAX_ORDER)
         assert isinstance(result, float)
         assert not math.isnan(result) and not math.isinf(result)
+
+
+# ===========================================================================
+# Tests: _seq_to_int_fast() and build_numba_log_table()
+# ===========================================================================
+
+
+class TestSeqToIntFast:
+    """Tests for the vectorised DNA→int32 encoder."""
+
+    def test_known_nucleotides_map_correctly(self):
+        arr = _seq_to_int_fast("ACGT")
+        assert list(arr) == [0, 1, 2, 3]
+
+    def test_unknown_nucleotide_maps_to_four(self):
+        arr = _seq_to_int_fast("N")
+        assert arr[0] == 4
+
+    def test_output_dtype_is_int32(self):
+        import numpy as np
+        arr = _seq_to_int_fast("ACGT")
+        assert arr.dtype == np.int32
+
+    def test_output_length_matches_input(self):
+        seq = "ATGCATGCATGC"
+        assert len(_seq_to_int_fast(seq)) == len(seq)
+
+    def test_lut_constant_covers_all_four_bases(self):
+        assert _ASCII_TO_INT[65] == 0  # A
+        assert _ASCII_TO_INT[67] == 1  # C
+        assert _ASCII_TO_INT[71] == 2  # G
+        assert _ASCII_TO_INT[84] == 3  # T
+
+    def test_lut_default_is_four_for_unknown(self):
+        # Every entry not explicitly set should be 4
+        import numpy as np
+        other_indices = [i for i in range(128) if i not in (65, 67, 71, 84)]
+        assert all(_ASCII_TO_INT[i] == 4 for i in other_indices)
+
+    def test_round_trip_on_coding_sequence(self):
+        seq = "ATG" + "CAG" * 10 + "TAA"
+        arr = _seq_to_int_fast(seq)
+        assert len(arr) == len(seq)
+        assert arr[0] == 0   # A
+        assert arr[1] == 3   # T
+        assert arr[2] == 2   # G
+
+
+class TestBuildNumbaLogTable:
+    """Tests for the integer-indexed numpy log table."""
+
+    _CODING_SEQS    = ["ATG" + "CAG" * 30 + "TAA"] * 5
+    _MAX_ORDER = 2
+
+    @pytest.fixture(scope="class")
+    def log_table(self):
+        imm = build_interpolated_markov_model(self._CODING_SEQS, self._MAX_ORDER)
+        return build_flat_log_table(imm, self._MAX_ORDER)
+
+    @pytest.fixture(scope="class")
+    def numba_table(self, log_table):
+        return build_numba_log_table(log_table, self._MAX_ORDER)
+
+    def test_returns_numpy_array(self, numba_table):
+        import numpy as np
+        assert isinstance(numba_table, np.ndarray)
+
+    def test_shape_is_positions_by_entries(self, numba_table):
+        # 3 positions, (4^(max_order+2)-1)//3 entries
+        expected_cols = (4 ** (self._MAX_ORDER + 2) - 1) // 3
+        assert numba_table.shape == (3, expected_cols)
+
+    def test_all_values_non_positive(self, numba_table):
+        assert (numba_table <= 0).all()
+
+    def test_all_values_at_least_log_epsilon(self, numba_table):
+        assert (numba_table >= _LOG_EPSILON - 1e-12).all()
+
+    def test_single_nucleotide_entries_match_flat_table(self, log_table, numba_table):
+        """Index for single-char key 'A' (no context) must match flat table value."""
+        # key='A': len=1, offset=(4^1-1)//3=1, idx=1+0=1 (A=0)
+        assert abs(numba_table[0, 1] - log_table[0].get("A", _LOG_EPSILON)) < 1e-12
+
+
+@pytest.mark.skipif(not _NUMBA_AVAILABLE, reason="numba not installed")
+class TestScoreImmNumba:
+    """Regression tests for the Numba JIT scoring path."""
+
+    _CODING_SEQS    = ["ATG" + "CAG" * 30 + "TAA"] * 5
+    _NONCODING_SEQS = ["GGG" * 31] * 5
+    _MAX_ORDER = 2
+
+    @pytest.fixture(scope="class")
+    def tables(self):
+        from src.traditional_methods import _score_imm_numba
+        coding_imm    = build_interpolated_markov_model(self._CODING_SEQS,    self._MAX_ORDER)
+        noncoding_imm = build_interpolated_markov_model(self._NONCODING_SEQS, self._MAX_ORDER)
+        flat_c  = build_flat_log_table(coding_imm,    self._MAX_ORDER)
+        flat_nc = build_flat_log_table(noncoding_imm, self._MAX_ORDER)
+        c_tbl   = build_numba_log_table(flat_c,  self._MAX_ORDER)
+        nc_tbl  = build_numba_log_table(flat_nc, self._MAX_ORDER)
+        return coding_imm, noncoding_imm, c_tbl, nc_tbl, _score_imm_numba
+
+    def test_short_sequence_returns_zero(self, tables):
+        import numpy as np
+        _, _, c_tbl, nc_tbl, fn = tables
+        arr = np.array([0, 1], dtype=np.int32)
+        assert fn(arr, c_tbl, nc_tbl, self._MAX_ORDER, _LOG_EPSILON) == 0.0
+
+    def test_identical_to_score_imm_ratio_on_coding_seq(self, tables):
+        coding_imm, noncoding_imm, c_tbl, nc_tbl, fn = tables
+        seq = "ATG" + "CAG" * 20 + "TAA"
+        clear_imm_cache()
+        old = score_imm_ratio(seq, coding_imm, noncoding_imm, self._MAX_ORDER)
+        new = float(fn(_seq_to_int_fast(seq), c_tbl, nc_tbl, self._MAX_ORDER, _LOG_EPSILON))
+        assert old == pytest.approx(new, abs=1e-12)
+
+    def test_identical_to_score_imm_ratio_on_noncoding_seq(self, tables):
+        coding_imm, noncoding_imm, c_tbl, nc_tbl, fn = tables
+        seq = "GGG" * 30
+        clear_imm_cache()
+        old = score_imm_ratio(seq, coding_imm, noncoding_imm, self._MAX_ORDER)
+        new = float(fn(_seq_to_int_fast(seq), c_tbl, nc_tbl, self._MAX_ORDER, _LOG_EPSILON))
+        assert old == pytest.approx(new, abs=1e-12)
+
+    def test_identical_on_100_random_sequences(self, tables):
+        import random
+        random.seed(99)
+        coding_imm, noncoding_imm, c_tbl, nc_tbl, fn = tables
+        clear_imm_cache()
+        for _ in range(100):
+            seq = "".join(random.choice("ACGT") for _ in range(random.randint(30, 300)))
+            old = score_imm_ratio(seq, coding_imm, noncoding_imm, self._MAX_ORDER)
+            new = float(fn(_seq_to_int_fast(seq), c_tbl, nc_tbl, self._MAX_ORDER, _LOG_EPSILON))
+            assert old == pytest.approx(new, abs=1e-12), f"mismatch on {seq[:20]!r}"
+
+    def test_coding_scores_higher_than_noncoding(self, tables):
+        _, _, c_tbl, nc_tbl, fn = tables
+        s_cod = float(fn(_seq_to_int_fast("ATG" + "CAG" * 20 + "TAA"),
+                         c_tbl, nc_tbl, self._MAX_ORDER, _LOG_EPSILON))
+        s_non = float(fn(_seq_to_int_fast("GGG" * 20),
+                         c_tbl, nc_tbl, self._MAX_ORDER, _LOG_EPSILON))
+        assert s_cod > s_non
+
+    def test_unknown_nucleotide_no_crash(self, tables):
+        _, _, c_tbl, nc_tbl, fn = tables
+        result = float(fn(_seq_to_int_fast("ATGNNNNTAA" * 5),
+                          c_tbl, nc_tbl, self._MAX_ORDER, _LOG_EPSILON))
+        assert not math.isnan(result) and not math.isinf(result)
+
+
+# ===========================================================================
+# Tests: build_codon_log_ratio_table() and _score_codon_bias_numba()
+# ===========================================================================
+
+
+class TestBuildCodonLogRatioTable:
+    _CODING_SEQS    = [{"sequence": "ATG" + "CAG" * 30 + "TAA"}] * 5
+    _NONCODING_SEQS = [{"sequence": "GGG" * 31}] * 5
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        c  = build_codon_model(self._CODING_SEQS)
+        bg = build_codon_model(self._NONCODING_SEQS)
+        return c, bg
+
+    @pytest.fixture(scope="class")
+    def table(self, models):
+        return build_codon_log_ratio_table(*models)
+
+    def test_returns_numpy_array(self, table):
+        import numpy as np
+        assert isinstance(table, np.ndarray)
+
+    def test_shape_is_64(self, table):
+        assert table.shape == (64,)
+
+    def test_all_values_are_finite(self, table):
+        import numpy as np
+        assert np.all(np.isfinite(table))
+
+    def test_neutral_for_unseen_codon(self):
+        # Empty models → all unseen → all entries = log(1e-4) - log(1e-4) = 0.0
+        table = build_codon_log_ratio_table({}, {})
+        assert (table == 0.0).all()
+
+    def test_known_codon_has_nonzero_ratio(self, table):
+        # CAG is in coding but not noncoding → ratio should be nonzero
+        assert any(v != 0.0 for v in table)
+
+    def test_atg_index(self, models):
+        # ATG: A=0, T=3, G=2 → 0*16 + 3*4 + 2 = 14
+        c, bg = models
+        table = build_codon_log_ratio_table(c, bg)
+        c_freq  = c.get("ATG",  1e-4)
+        bg_freq = bg.get("ATG", 1e-4)
+        expected = math.log(c_freq) - math.log(bg_freq)
+        assert abs(table[14] - expected) < 1e-12
+
+
+@pytest.mark.skipif(not _NUMBA_AVAILABLE, reason="numba not installed")
+class TestScoreCodonBiasNumba:
+    _CODING_SEQS    = [{"sequence": "ATG" + "CAG" * 30 + "TAA"}] * 5
+    _NONCODING_SEQS = [{"sequence": "GGG" * 31}] * 5
+
+    @pytest.fixture(scope="class")
+    def setup(self):
+        from src.traditional_methods import _score_codon_bias_numba
+        c  = build_codon_model(self._CODING_SEQS)
+        bg = build_codon_model(self._NONCODING_SEQS)
+        tbl = build_codon_log_ratio_table(c, bg)
+        return c, bg, tbl, _score_codon_bias_numba
+
+    def test_empty_sequence_returns_zero(self, setup):
+        import numpy as np
+        _, _, tbl, fn = setup
+        assert fn(np.array([], dtype=np.int32), tbl) == 0.0
+
+    def test_all_n_returns_zero(self, setup):
+        _, _, tbl, fn = setup
+        arr = _seq_to_int_fast("NNN" * 10)
+        assert fn(arr, tbl) == 0.0
+
+    def test_returns_float(self, setup):
+        _, _, tbl, fn = setup
+        result = fn(_seq_to_int_fast("ATG" + "CAG" * 10 + "TAA"), tbl)
+        assert isinstance(float(result), float)
+
+    def test_identical_to_score_codon_bias_ratio_on_coding_seq(self, setup):
+        """Regression: Numba path must produce same result as Python fallback."""
+        c, bg, tbl, fn = setup
+        seq = "ATG" + "CAG" * 20 + "TAA"
+        old = score_codon_bias_ratio(seq, c, bg)
+        new = float(fn(_seq_to_int_fast(seq), tbl))
+        assert old == pytest.approx(new, abs=1e-10)
+
+    def test_identical_to_score_codon_bias_ratio_on_noncoding_seq(self, setup):
+        c, bg, tbl, fn = setup
+        seq = "GGG" * 30
+        old = score_codon_bias_ratio(seq, c, bg)
+        new = float(fn(_seq_to_int_fast(seq), tbl))
+        assert old == pytest.approx(new, abs=1e-10)
+
+    def test_identical_on_100_random_sequences(self, setup):
+        import random
+        random.seed(7)
+        c, bg, tbl, fn = setup
+        for _ in range(100):
+            seq = "".join(random.choice("ACGT") for _ in range(random.randint(9, 300)))
+            old = score_codon_bias_ratio(seq, c, bg)
+            new = float(fn(_seq_to_int_fast(seq), tbl))
+            assert old == pytest.approx(new, abs=1e-10), f"mismatch on {seq[:20]!r}"
+
+    def test_coding_scores_higher_than_noncoding(self, setup):
+        _, _, tbl, fn = setup
+        s_cod = float(fn(_seq_to_int_fast("ATG" + "CAG" * 20 + "TAA"), tbl))
+        s_non = float(fn(_seq_to_int_fast("GGG" * 20), tbl))
+        assert s_cod > s_non
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Extends the Numba JIT infrastructure from PR #83 (IMM scoring) to cover codon bias scoring, and shares the sequence encoding between both — eliminating the dominant remaining bottleneck.

## What changed

- `_score_codon_bias_numba()` — `@njit(cache=True)` inner loop; 64-entry base-4 indexed numpy table; one array lookup per codon vs. two `dict.get()` + two `math.log()` calls before
- `build_codon_log_ratio_table()` — pre-computes `log(coding/background)` for all 64 codons at model-build time
- `score_all_orfs()` — encodes each sequence **once** with `_seq_to_int_fast()` and reuses the `int32` array for both IMM and codon scoring; eliminates double-encoding overhead
- `requirements.txt` — adds `numba>=0.57.0`

## Benchmark (E. coli K-12, 176,315 ORFs)

| Component | Before | After | Speedup |
|---|---|---|---|
| `score_codon_bias_ratio` | 12.46s | 0.07s | **178×** |
| IMM scoring | 2.62s | 0.70s | 3.7× |
| `score_all_orfs` total | ~95s (original) | **~1.4s** | **~68×** |

`Scoring complete in 0.0 minutes` — rounds to zero.

## Correctness

- 98 unit tests pass, including 13 new regression tests for `build_codon_log_ratio_table` and `_score_codon_bias_numba`
- Full 12-step pipeline on E. coli K-12: 3,976 predictions, Sens 78.7%, Prec 85.9%, F1 82.2% — unchanged from pre-optimisation baseline

Closes #84