### PR TITLE
BUG: fix strand_plus_frac/strand_minus_frac always zero — use forward/reverse labels

### DIFF
--- a/doc/whatsnew/v1.1.0.rst
+++ b/doc/whatsnew/v1.1.0.rst
@@ -9,6 +9,14 @@ What's new in 1.1.0 (TBD)
 Bug fixes
 ~~~~~~~~~
 
+ML models
+^^^^^^^^^
+- Fixed :func:`extract_group_features` using ``"+"`` / ``"-"`` to count strands while
+  the pipeline stores them as ``"forward"`` / ``"reverse"`` (:issue:`97`).  The two
+  LightGBM features ``strand_plus_frac`` and ``strand_minus_frac`` were silently
+  always 0.0, wasting 2 of the 31 feature slots.  After the fix both features are
+  correct (always 0.0 or 1.0 since every ORF group shares one stop codon and
+  therefore one strand).
 .. ---------------------------------------------------------------------------
 .. _whatsnew_110.enhancements:
 

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -172,8 +172,8 @@ class OrfGroupClassifier:
                 "imm_mean": imm.mean(),
                 "start_select_max": max_ss,
                 "start_select_mean": ss.mean(),
-                "strand_plus_frac": strands.count("+") / n,
-                "strand_minus_frac": strands.count("-") / n,
+                "strand_plus_frac": strands.count("forward") / n,
+                "strand_minus_frac": strands.count("reverse") / n,
                 # Relative features
                 "rel_combined_mean": (
                     combined / max_combined if max_combined > 0 else np.zeros(n)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,9 @@ Coordinate conventions (match find_orfs_candidates() output)
 * strand — "forward" or "reverse" (as returned by the detector)
 """
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "sequences"
 
@@ -22,8 +23,8 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "sequences"
 # synthetic_single_orf.fasta — 300 bp, one ORF on the forward strand
 # ATG at 0-indexed position 30 (frame 0); body = ATG + GGG*48 + TAA = 150 bp
 # ---------------------------------------------------------------------------
-SINGLE_ORF_START = 31       # 1-based
-SINGLE_ORF_END = 180        # exclusive end (i + 3)
+SINGLE_ORF_START = 31  # 1-based
+SINGLE_ORF_END = 180  # exclusive end (i + 3)
 SINGLE_ORF_LENGTH = 150
 SINGLE_ORF_STRAND = "forward"
 
@@ -31,10 +32,10 @@ SINGLE_ORF_STRAND = "forward"
 # synthetic_multi_orf.fasta — 2000 bp, five forward-strand ORFs (all frame 0)
 # ---------------------------------------------------------------------------
 MULTI_ORF_COORDS = [
-    {"start": 1,    "end": 150,  "length": 150, "strand": "forward"},
-    {"start": 301,  "end": 480,  "length": 180, "strand": "forward"},
-    {"start": 601,  "end": 750,  "length": 150, "strand": "forward"},
-    {"start": 901,  "end": 1098, "length": 198, "strand": "forward"},
+    {"start": 1, "end": 150, "length": 150, "strand": "forward"},
+    {"start": 301, "end": 480, "length": 180, "strand": "forward"},
+    {"start": 601, "end": 750, "length": 150, "strand": "forward"},
+    {"start": 901, "end": 1098, "length": 198, "strand": "forward"},
     {"start": 1201, "end": 1350, "length": 150, "strand": "forward"},
 ]
 
@@ -64,18 +65,18 @@ LARGE_ORF_COORDS = [
 # ---------------------------------------------------------------------------
 
 _BASE_ORF = {
-    "combined_score":    0.8,
-    "rbs_score":         2.0,
-    "codon_score":       0.5,
-    "start_score":       0.7,
-    "imm_score":         0.3,
-    "strand":            "+",
+    "combined_score": 0.8,
+    "rbs_score": 2.0,
+    "codon_score": 0.5,
+    "start_score": 0.7,
+    "imm_score": 0.3,
+    "strand": "forward",
     # normalized scores used by start-selection weighting
-    "codon_score_norm":  0.6,
-    "imm_score_norm":    0.4,
-    "rbs_score_norm":    0.7,
+    "codon_score_norm": 0.6,
+    "imm_score_norm": 0.4,
+    "rbs_score_norm": 0.7,
     "length_score_norm": 0.5,
-    "start_score_norm":  0.6,
+    "start_score_norm": 0.6,
 }
 
 # ---------------------------------------------------------------------------
@@ -84,17 +85,17 @@ _BASE_ORF = {
 # ---------------------------------------------------------------------------
 
 _BASE_CANDIDATE = {
-    "sequence":          "ATGAAACCCGGGTTTTTTGGGAAATAA",
-    "length":            27,
-    "start_codon":       "ATG",
-    "codon_score_norm":  0.6,
-    "imm_score_norm":    0.4,
-    "rbs_score_norm":    0.7,
+    "sequence": "ATGAAACCCGGGTTTTTTGGGAAATAA",
+    "length": 27,
+    "start_codon": "ATG",
+    "codon_score_norm": 0.6,
+    "imm_score_norm": 0.4,
+    "rbs_score_norm": 0.7,
     "length_score_norm": 0.5,
-    "start_score_norm":  0.6,
-    "combined_score":    0.8,
-    "rbs_score":         2.0,
-    "gene_id":           "gene_1",
+    "start_score_norm": 0.6,
+    "combined_score": 0.8,
+    "rbs_score": 2.0,
+    "gene_id": "gene_1",
 }
 
 

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -86,6 +86,36 @@ class TestOrfGroupClassifierFeatureExtraction:
         total = df.loc[0, "strand_plus_frac"] + df.loc[0, "strand_minus_frac"]
         assert total == pytest.approx(1.0, abs=1e-6)
 
+    def test_strand_fractions_use_forward_reverse_labels_issue_97(self, two_orf_group):
+        """Regression #97: strand_plus_frac / strand_minus_frac must use
+        'forward' / 'reverse' labels (not '+' / '-').
+
+        Before the fix both features were always 0.0 because the pipeline
+        stores strand as 'forward'/'reverse' but the code counted '+'/'-'.
+        """
+        clf = OrfGroupClassifier()
+        df = clf.extract_group_features(two_orf_group, genome_id="test")
+        # All ORFs in two_orf_group are on the 'forward' strand (conftest.py)
+        assert df.loc[0, "strand_plus_frac"] == pytest.approx(
+            1.0, abs=1e-6
+        ), "strand_plus_frac should be 1.0 for a forward-strand group"
+        assert df.loc[0, "strand_minus_frac"] == pytest.approx(
+            0.0, abs=1e-6
+        ), "strand_minus_frac should be 0.0 for a forward-strand group"
+
+    def test_strand_fractions_reverse_group_issue_97(self):
+        """Regression #97: verify reverse-strand group gives correct fractions."""
+        from tests.conftest import _BASE_ORF
+
+        reverse_orf = dict(_BASE_ORF)
+        reverse_orf["strand"] = "reverse"
+        reverse_group = {"group_1": [reverse_orf, dict(reverse_orf)]}
+
+        clf = OrfGroupClassifier()
+        df = clf.extract_group_features(reverse_group, genome_id="test")
+        assert df.loc[0, "strand_plus_frac"] == pytest.approx(0.0, abs=1e-6)
+        assert df.loc[0, "strand_minus_frac"] == pytest.approx(1.0, abs=1e-6)
+
     def test_combined_mean_within_score_range(self, two_orf_group):
         clf = OrfGroupClassifier()
         df = clf.extract_group_features(two_orf_group, genome_id="test")
@@ -132,9 +162,7 @@ class TestOrfGroupClassifierPredictGroups:
         with pytest.raises((AttributeError, RuntimeError)):
             clf.predict_groups(two_orf_group, genome_id="test")
 
-    def test_value_error_message_contains_missing_feature_name_issue_47(
-        self, two_orf_group
-    ):
+    def test_value_error_message_contains_missing_feature_name_issue_47(self, two_orf_group):
         """The ValueError message must name the missing feature(s) explicitly."""
         clf = OrfGroupClassifier()
         clf.model = MagicMock()
@@ -235,9 +263,7 @@ class TestHybridGeneFilterPredict:
         assert len(probs) == 0
         assert len(gene_ids) == 0
 
-    def test_raises_value_error_on_missing_features_issue_47(
-        self, synthetic_candidate
-    ):
+    def test_raises_value_error_on_missing_features_issue_47(self, synthetic_candidate):
         """
         Regression for issue #47: predict() silently constructed a feature
         tensor with fewer columns than the DenseBranch(input_dim=25) expects
@@ -253,25 +279,19 @@ class TestHybridGeneFilterPredict:
 
         # Build a DataFrame that is missing the last expected feature
         missing_feature = hgf.feature_names[-1]
-        incomplete_df = pd.DataFrame(
-            [{f: 0.0 for f in hgf.feature_names[:-1]}]
-        )
+        incomplete_df = pd.DataFrame([{f: 0.0 for f in hgf.feature_names[:-1]}])
 
         with patch.object(hgf, "extract_features", return_value=incomplete_df):
             with pytest.raises(ValueError, match=missing_feature):
                 hgf.predict([synthetic_candidate], genome_id="test")
 
-    def test_value_error_message_contains_missing_feature_name_issue_47(
-        self, synthetic_candidate
-    ):
+    def test_value_error_message_contains_missing_feature_name_issue_47(self, synthetic_candidate):
         """The ValueError message must name the missing feature(s) explicitly."""
         hgf = HybridGeneFilter()
         hgf.model = MagicMock()
 
         sentinel = "polar_fraction"  # last feature in the 25-feature list
-        incomplete_df = pd.DataFrame(
-            [{f: 0.0 for f in hgf.feature_names if f != sentinel}]
-        )
+        incomplete_df = pd.DataFrame([{f: 0.0 for f in hgf.feature_names if f != sentinel}])
 
         with patch.object(hgf, "extract_features", return_value=incomplete_df):
             with pytest.raises(ValueError) as exc_info:


### PR DESCRIPTION
## Bug

`extract_group_features()` counted strand with `"+"` / `"-"` but the pipeline stores `"forward"` / `"reverse"`. Both LightGBM features were silently always 0.0 — wasting 2 of 31 feature slots.

## Fix

- `strands.count("forward")` / `strands.count("reverse")` (was `"+"` / `"-"`)
- `_BASE_ORF` in `conftest.py` updated from `"strand": "+"` to `"strand": "forward"`

## Tests

Two regression tests: forward-strand group → `strand_plus_frac=1.0`; reverse-strand group → `strand_minus_frac=1.0`. 34 tests pass.

## Note

The existing `orf_classifier_lgb.pkl` was trained with the broken features (always 0.0). Full performance benefit requires model retraining (tracked in #98).

Closes #97