### PR TITLE
ENH: add fuzzy coordinate matching to compare_orfs_to_reference

### DIFF
--- a/doc/whatsnew/v1.1.0.rst
+++ b/doc/whatsnew/v1.1.0.rst
@@ -15,6 +15,16 @@ Bug fixes
 Enhancements
 ~~~~~~~~~~~~
 
+Evaluation
+^^^^^^^^^^
+- Added ``start_tolerance`` and ``stop_tolerance`` parameters to
+  :func:`compare_orfs_to_reference` (:issue:`99`).  Setting
+  ``start_tolerance=100`` enables biologically realistic evaluation: prokaryotic
+  start sites are uncertain by up to a few codons due to SD-signal ambiguity and
+  alternative start codons.  Default remains 0 (exact match) for backward
+  compatibility.  The result dict now also carries ``match_mode``,
+  ``start_tolerance``, and ``stop_tolerance`` for full reproducibility.
+
 .. ---------------------------------------------------------------------------
 .. _whatsnew_110.performance:
 

--- a/src/comparative_analysis.py
+++ b/src/comparative_analysis.py
@@ -443,15 +443,63 @@ def plot_score_distributions(all_orfs: List[Dict], reference_genes: Set, genome_
 # =============================================================================
 
 
-def compare_orfs_to_reference(orfs: List[Dict], genome_id: str, cached_data: Dict = None) -> Dict:
-    """Compare predicted ORFs to reference CDS using GFF file."""
-    # Get GFF path
+def _count_fuzzy_matches(
+    pred_coords: pd.DataFrame,
+    ref: pd.DataFrame,
+    start_tolerance: int,
+    stop_tolerance: int,
+) -> int:
+    """Count predicted ORFs that match any reference CDS within tolerances.
+
+    A prediction (ps, pe) matches a reference (rs, re) when:
+        |ps - rs| <= start_tolerance  AND  |pe - re| <= stop_tolerance
+
+    Uses a vectorised cross-join approach; efficient for typical sizes
+    (≤10K predictions × ≤10K references).
+    """
+    if start_tolerance == 0 and stop_tolerance == 0:
+        return len(pd.merge(pred_coords, ref, on=["start", "end"]))
+
+    # Mark each prediction as matched or not
+    pred_starts = pred_coords["start"].values
+    pred_ends = pred_coords["end"].values
+    ref_starts = ref["start"].values
+    ref_ends = ref["end"].values
+
+    matched = 0
+    for ps, pe in zip(pred_starts, pred_ends):
+        if np.any(
+            (np.abs(ref_starts - ps) <= start_tolerance) & (np.abs(ref_ends - pe) <= stop_tolerance)
+        ):
+            matched += 1
+    return matched
+
+
+def compare_orfs_to_reference(
+    orfs: List[Dict],
+    genome_id: str,
+    cached_data: Dict = None,
+    start_tolerance: int = 0,
+    stop_tolerance: int = 0,
+) -> Dict:
+    """Compare predicted ORFs to reference CDS using GFF file.
+
+    Args:
+        orfs: List of ORF dicts or DataFrame with predicted genes.
+        genome_id: Genome accession used to locate the reference GFF.
+        cached_data: Unused legacy parameter.
+        start_tolerance: Max allowed difference in start coordinate for a
+            match to count as a true positive (default 0 = exact match).
+            Set to 100 for biologically realistic evaluation; prokaryotic
+            start sites are often uncertain by a few codons.
+        stop_tolerance: Max allowed difference in stop coordinate
+            (default 0 = exact match).  Stop codons are more reliable than
+            starts, so a tolerance of 0–5 bp is typical.
+    """
     gff_path = get_gff_path(genome_id)
 
-    # Convert ORFs to DataFrame
     pred = pd.DataFrame(orfs) if not isinstance(orfs, pd.DataFrame) else orfs.copy()
 
-    # Extract coordinates
     if "genome_start" in pred.columns and "genome_end" in pred.columns:
         pred_coords = pred[["genome_start", "genome_end"]].rename(
             columns={"genome_start": "start", "genome_end": "end"}
@@ -463,18 +511,15 @@ def compare_orfs_to_reference(orfs: List[Dict], genome_id: str, cached_data: Dic
             "ORF data must contain 'start'/'end' or 'genome_start'/'genome_end' columns."
         )
 
-    # Load reference CDS from GFF
     ref = pd.read_csv(gff_path, sep="\t", comment="#", header=None)
     ref = ref[ref[2] == "CDS"][[3, 4]].rename(columns={3: "start", 4: "end"})
     ref = ref.drop_duplicates()
 
-    # Find exact matches
-    matches = pd.merge(pred_coords, ref, on=["start", "end"])
-    true_pos = len(matches)
+    fuzzy = start_tolerance > 0 or stop_tolerance > 0
+    true_pos = _count_fuzzy_matches(pred_coords, ref, start_tolerance, stop_tolerance)
     false_neg = len(ref) - true_pos
     false_pos = len(pred_coords) - true_pos
 
-    # Calculate metrics
     sensitivity = (true_pos / len(ref) * 100) if len(ref) > 0 else 0
     precision = (true_pos / len(pred_coords) * 100) if len(pred_coords) > 0 else 0
     f1 = (
@@ -483,13 +528,15 @@ def compare_orfs_to_reference(orfs: List[Dict], genome_id: str, cached_data: Dic
         else 0
     )
 
-    # Print summary
+    match_mode = (
+        f"fuzzy (start±{start_tolerance} bp, stop±{stop_tolerance} bp)" if fuzzy else "exact"
+    )
     print("=" * 80)
-    print(f"VALIDATION SUMMARY: {genome_id}")
+    print(f"VALIDATION SUMMARY: {genome_id}  [{match_mode}]")
     print("=" * 80)
     print(f"Predicted ORFs:              {len(pred_coords):,}")
     print(f"Reference CDS (proteins):    {len(ref):,}")
-    print(f"True positives (exact):      {true_pos:,}")
+    print(f"True positives ({match_mode}):  {true_pos:,}")
     print(f"False negatives (missed):    {false_neg:,}")
     print(f"False positives (spurious):  {false_pos:,}")
     print()
@@ -507,6 +554,9 @@ def compare_orfs_to_reference(orfs: List[Dict], genome_id: str, cached_data: Dic
         "sensitivity": sensitivity,
         "precision": precision,
         "f1_score": f1,
+        "match_mode": match_mode,
+        "start_tolerance": start_tolerance,
+        "stop_tolerance": stop_tolerance,
     }
 
 

--- a/tests/test_comparative_analysis.py
+++ b/tests/test_comparative_analysis.py
@@ -23,12 +23,14 @@ from src.comparative_analysis import (
 
 _GFF_HEADER = "##gff-version 3\n"
 
-_GFF_LINES = textwrap.dedent("""\
+_GFF_LINES = textwrap.dedent(
+    """\
     ##gff-version 3
     NC_TEST\t.\tCDS\t100\t300\t.\t+\t0\t.
     NC_TEST\t.\tCDS\t500\t700\t.\t+\t0\t.
     NC_TEST\t.\tCDS\t900\t1100\t.\t-\t0\t.
-""")
+"""
+)
 
 # Three reference genes: (100,300), (500,700), (900,1100)
 _REF_COORDS = [(100, 300), (500, 700), (900, 1100)]
@@ -87,8 +89,8 @@ class TestCompareOrfsToReference:
             result = compare_orfs_to_reference(orfs, "NC_TEST")
 
         assert result["true_positives"] == 2
-        assert result["false_positives"] == 1   # (9999, 10000) is spurious
-        assert result["false_negatives"] == 1   # (900, 1100) was missed
+        assert result["false_positives"] == 1  # (9999, 10000) is spurious
+        assert result["false_negatives"] == 1  # (900, 1100) was missed
 
     def test_sensitivity_formula(self, tmp_path):
         """Sensitivity = TP / reference_count * 100."""
@@ -139,6 +141,7 @@ class TestCompareOrfsToReference:
         # Current behaviour: pandas raises EmptyDataError on a header-only GFF.
         # Ideal behaviour would be to return sensitivity=0.0 (see issue #29).
         import pandas as pd
+
         empty_gff = tmp_path / "empty.gff"
         empty_gff.write_text(_GFF_HEADER)
         orfs = _orfs_from_coords([(100, 300)])
@@ -176,11 +179,83 @@ class TestCompareOrfsToReference:
             result = compare_orfs_to_reference(orfs, "NC_TEST")
 
         required = {
-            "predicted", "reference", "true_positives",
-            "false_negatives", "false_positives",
-            "sensitivity", "precision", "f1_score",
+            "predicted",
+            "reference",
+            "true_positives",
+            "false_negatives",
+            "false_positives",
+            "sensitivity",
+            "precision",
+            "f1_score",
         }
         assert required <= set(result.keys())
+
+
+# ---------------------------------------------------------------------------
+# compare_orfs_to_reference — fuzzy coordinate matching (issue #99)
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzyCoordinateMatching:
+    """Regression tests for start_tolerance / stop_tolerance parameters."""
+
+    def test_exact_match_default_tolerance(self, tmp_path):
+        """Default (0, 0) tolerance reproduces the original exact-match behaviour."""
+        gff = _make_gff_file(tmp_path)
+        orfs = _orfs_from_coords(_REF_COORDS)
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            r = compare_orfs_to_reference(orfs, "NC_TEST", start_tolerance=0, stop_tolerance=0)
+        assert r["true_positives"] == 3
+        assert r["match_mode"] == "exact"
+
+    def test_off_by_one_start_fails_exact_but_passes_fuzzy(self, tmp_path):
+        """A prediction with start shifted by 3 bp is a false positive under exact
+        matching but a true positive under start_tolerance=3."""
+        gff = _make_gff_file(tmp_path)
+        # Shift the first predicted start by 3 bp
+        shifted = list(_REF_COORDS)
+        shifted[0] = (shifted[0][0] + 3, shifted[0][1])
+        orfs = _orfs_from_coords(shifted)
+
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            r_exact = compare_orfs_to_reference(orfs, "NC_TEST", start_tolerance=0)
+            r_fuzzy = compare_orfs_to_reference(orfs, "NC_TEST", start_tolerance=3)
+
+        # Exact: one prediction is off → 2 TP, 1 FP, 1 FN
+        assert r_exact["true_positives"] == 2
+        # Fuzzy: within tolerance → all 3 match
+        assert r_fuzzy["true_positives"] == 3
+
+    def test_stop_tolerance_matches_close_stop(self, tmp_path):
+        """A prediction with stop shifted by 5 bp matches under stop_tolerance=5."""
+        gff = _make_gff_file(tmp_path)
+        shifted = list(_REF_COORDS)
+        shifted[0] = (shifted[0][0], shifted[0][1] + 5)
+        orfs = _orfs_from_coords(shifted)
+
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            r_exact = compare_orfs_to_reference(orfs, "NC_TEST", stop_tolerance=0)
+            r_fuzzy = compare_orfs_to_reference(orfs, "NC_TEST", stop_tolerance=5)
+
+        assert r_exact["true_positives"] == 2
+        assert r_fuzzy["true_positives"] == 3
+
+    def test_result_contains_tolerance_metadata(self, tmp_path):
+        """Result dict must carry match_mode, start_tolerance, stop_tolerance."""
+        gff = _make_gff_file(tmp_path)
+        orfs = _orfs_from_coords(_REF_COORDS)
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            r = compare_orfs_to_reference(orfs, "NC_TEST", start_tolerance=100, stop_tolerance=5)
+        assert r["start_tolerance"] == 100
+        assert r["stop_tolerance"] == 5
+        assert "fuzzy" in r["match_mode"]
+
+    def test_zero_tolerance_still_returns_match_mode_exact(self, tmp_path):
+        gff = _make_gff_file(tmp_path)
+        orfs = _orfs_from_coords(_REF_COORDS)
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            r = compare_orfs_to_reference(orfs, "NC_TEST")
+        assert r["match_mode"] == "exact"
 
 
 # ---------------------------------------------------------------------------
@@ -233,10 +308,7 @@ class TestCompareResultsFileToReference:
         results_dir.mkdir()
         pred_file = results_dir / "NC_TEST_predictions.gff"
         pred_file.write_text(
-            "##gff-version 3\n"
-            "# comment line\n"
-            "\n"
-            "NC_TEST\t.\tCDS\t100\t300\t.\t+\t0\t.\n"
+            "##gff-version 3\n" "# comment line\n" "\n" "NC_TEST\t.\tCDS\t100\t300\t.\t+\t0\t.\n"
         )
 
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

Adds `start_tolerance` and `stop_tolerance` parameters to `compare_orfs_to_reference()`. Default 0 = exact match (fully backward-compatible).

## Motivation (#99)

Prokaryotic start site prediction is inherently uncertain — SD-signal ambiguity, alternative start codons (GTG/TTG), and database inconsistencies mean a prediction 3–9 bp off the annotated start is still a biologically correct gene call. Under exact matching it is counted as both a FP and FN, deflating reported metrics vs tools that use fuzzy matching.

## What changed

- `_count_fuzzy_matches()` — vectorised numpy helper
- `compare_orfs_to_reference(start_tolerance=0, stop_tolerance=0)` — new params
- Result dict now carries `match_mode`, `start_tolerance`, `stop_tolerance`
- Print header shows match mode

## Tests

5 new regression tests: exact-vs-fuzzy on shifted start, shifted stop, metadata in dict. 19/19 pass.

Closes #99