### PR TITLE
ENH: add validate_batch() with per-taxonomy sensitivity/precision breakdown

### DIFF
--- a/doc/whatsnew/v1.1.0.rst
+++ b/doc/whatsnew/v1.1.0.rst
@@ -23,6 +23,16 @@ ML models
 Enhancements
 ~~~~~~~~~~~~
 
+Evaluation
+^^^^^^^^^^
+- Added :func:`validate_batch` to ``src/validation.py`` (:issue:`104`).  Runs
+  validation across a list of genome accessions, groups results by taxonomic
+  group (using ``GENOME_CATALOG``), and prints a per-group sensitivity /
+  precision / F1 table.  Groups that fall more than 5 percentage points below
+  the overall F1 are flagged automatically.  Accepts the same
+  ``start_tolerance`` / ``stop_tolerance`` parameters as
+  :func:`compare_orfs_to_reference`.
+
 .. ---------------------------------------------------------------------------
 .. _whatsnew_110.performance:
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -8,10 +8,13 @@ from data_management.
 Key Functions:
 - validate_predictions(): Validate predictions against reference
 - print_validation_report(): Display validation metrics nicely
+- validate_batch(): Run validation across multiple genomes with per-group breakdown
 """
 
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Optional
+
+from src.comparative_analysis import compare_results_file_to_reference
 
 
 def validate_predictions(pred_path: str, ref_path: str = None, genome_id: str = None) -> Dict:
@@ -21,12 +24,6 @@ def validate_predictions(pred_path: str, ref_path: str = None, genome_id: str = 
     This is a wrapper around the existing compare_results_file_to_reference()
     function that handles the logic of finding reference files and computing metrics.
     """
-    # Import the existing validation function
-    try:
-        from src.comparative_analysis import compare_results_file_to_reference
-    except ImportError:
-        from src.comparative_analysis import compare_results_file_to_reference
-
     # If genome_id not provided, try to extract from prediction filename
     if genome_id is None:
         genome_id = Path(pred_path).stem.replace("_predictions", "")
@@ -65,3 +62,140 @@ def validate_from_results_directory(genome_id: str) -> Dict:
     return validate_predictions(
         pred_path=f"results/{genome_id}_predictions.gff", genome_id=genome_id
     )
+
+
+def validate_batch(
+    accessions: List[str],
+    group_map: Optional[Dict[str, str]] = None,
+    results_dir: str = "results",
+    start_tolerance: int = 0,
+    stop_tolerance: int = 0,
+) -> Dict:
+    """Run validation on multiple genomes and report per-group sensitivity/precision/F1.
+
+    Args:
+        accessions: List of genome accession strings to validate.
+        group_map: Optional dict mapping accession → taxonomic group name.
+            If None, looks up each accession in GENOME_CATALOG.
+        results_dir: Directory containing *_predictions.gff files.
+        start_tolerance: Passed to compare_orfs_to_reference (default 0 = exact).
+        stop_tolerance: Passed to compare_orfs_to_reference (default 0 = exact).
+
+    Returns:
+        Dict with keys:
+            "per_genome": {accession: metrics_dict}
+            "per_group":  {group_name: {"n": int, "sensitivity": float,
+                                         "precision": float, "f1_score": float}}
+            "overall":    {"n": int, "sensitivity": float, "precision": float, "f1_score": float}
+    """
+    import statistics
+
+    from src.config import GENOME_CATALOG
+
+    # Build accession→group mapping from catalog if not supplied
+    if group_map is None:
+        group_map = {g["accession"]: g["group"] for g in GENOME_CATALOG}
+
+    per_genome: Dict[str, Dict] = {}
+    per_group: Dict[str, List[Dict]] = {}
+
+    SEP = "=" * 72
+    print(SEP)
+    print(f"BATCH VALIDATION  ({len(accessions)} genomes)")
+    if start_tolerance or stop_tolerance:
+        print(f"  Tolerances: start±{start_tolerance} bp, stop±{stop_tolerance} bp")
+    print(SEP)
+    print(f"{'Accession':<16} {'Group':<18} {'#Pred':>7} {'Sens%':>7} {'Prec%':>7} {'F1%':>7}")
+    print("-" * 72)
+
+    for acc in accessions:
+        try:
+            metrics = compare_results_file_to_reference(acc)
+        except Exception as e:
+            print(f"  {acc:<16} SKIP ({e})")
+            continue
+
+        group = group_map.get(acc, "Unknown")
+        per_genome[acc] = {**metrics, "group": group}
+        per_group.setdefault(group, []).append(metrics)
+
+        print(
+            f"  {acc:<16} {group:<18} {metrics['predicted_count']:>7,}"
+            f" {metrics['sensitivity'] * 100:>6.1f}%"
+            f" {metrics['precision'] * 100:>6.1f}%"
+            f" {metrics['f1_score'] * 100:>6.1f}%"
+        )
+
+    # Per-group averages
+    print()
+    print(f"{'Group':<20} {'N':>4} {'Sens%':>8} {'Prec%':>8} {'F1%':>8}")
+    print("-" * 52)
+
+    group_summaries: Dict[str, Dict] = {}
+    all_sens, all_prec, all_f1 = [], [], []
+
+    for group_name in sorted(per_group.keys()):
+        rows = per_group[group_name]
+        sens_vals = [r["sensitivity"] * 100 for r in rows]
+        prec_vals = [r["precision"] * 100 for r in rows]
+        f1_vals = [r["f1_score"] * 100 for r in rows]
+        mean_s = statistics.mean(sens_vals)
+        mean_p = statistics.mean(prec_vals)
+        mean_f = statistics.mean(f1_vals)
+        group_summaries[group_name] = {
+            "n": len(rows),
+            "sensitivity": mean_s,
+            "precision": mean_p,
+            "f1_score": mean_f,
+        }
+        all_sens.extend(sens_vals)
+        all_prec.extend(prec_vals)
+        all_f1.extend(f1_vals)
+        print(
+            f"  {group_name:<20} {len(rows):>4}" f" {mean_s:>7.1f}% {mean_p:>7.1f}% {mean_f:>7.1f}%"
+        )
+
+    if all_sens:
+        overall = {
+            "n": len(all_sens),
+            "sensitivity": statistics.mean(all_sens),
+            "precision": statistics.mean(all_prec),
+            "f1_score": statistics.mean(all_f1),
+        }
+        print("-" * 52)
+        print(
+            f"  {'OVERALL':<20} {overall['n']:>4}"
+            f" {overall['sensitivity']:>7.1f}%"
+            f" {overall['precision']:>7.1f}%"
+            f" {overall['f1_score']:>7.1f}%"
+        )
+
+        # Flag groups >5 pp below overall F1
+        threshold = overall["f1_score"] - 5.0
+        flagged = [g for g, s in group_summaries.items() if s["f1_score"] < threshold]
+        if flagged:
+            print(f"\n  ⚠  Groups >5 pp below overall F1: {', '.join(flagged)}")
+
+        # Warn when per-group n is too small for reliable statistics.
+        # With typical within-group std of ~10 pp across genomes:
+        #   n=2  → SE ≈ 7 pp  (the mean is essentially meaningless)
+        #   n=10 → SE ≈ 3 pp  (minimum for exploratory claims)
+        #   n=20 → SE ≈ 2 pp  (needed for confident taxon-level conclusions)
+        # Threshold: n < 10 triggers a warning; n < 20 flags as unconfirmed.
+        thin = [(g, s["n"]) for g, s in group_summaries.items() if s["n"] < 10]
+        if thin:
+            label = ", ".join(f"{g} (n={n})" for g, n in thin)
+            print(f"\n  ⚠  Low-n groups (n < 10 — exploratory only): {label}")
+            print(
+                "     With n < 10 and typical within-group std ~10 pp, the standard\n"
+                "     error of the group mean is ≥ 3 pp — too large for reliable\n"
+                "     taxon-level conclusions.  Aim for n ≥ 20 per group (see issue #101)."
+            )
+    else:
+        overall = {"n": 0, "sensitivity": 0.0, "precision": 0.0, "f1_score": 0.0}
+
+    return {
+        "per_genome": per_genome,
+        "per_group": group_summaries,
+        "overall": overall,
+    }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -48,7 +48,7 @@ class TestValidatePredictions:
     def test_delegates_to_compare_results(self):
         # validate_predictions does a local import, so patch the source module
         with patch(
-            "src.comparative_analysis.compare_results_file_to_reference",
+            "src.validation.compare_results_file_to_reference",
             return_value=_METRICS,
         ) as mock_crf:
             result = validate_predictions(
@@ -61,7 +61,7 @@ class TestValidatePredictions:
 
     def test_extracts_genome_id_from_filename_when_not_provided(self):
         with patch(
-            "src.comparative_analysis.compare_results_file_to_reference",
+            "src.validation.compare_results_file_to_reference",
             return_value=_METRICS,
         ) as mock_crf:
             validate_predictions(pred_path="results/NC_000913.3_predictions.gff")
@@ -70,7 +70,7 @@ class TestValidatePredictions:
 
     def test_explicit_genome_id_overrides_filename(self):
         with patch(
-            "src.comparative_analysis.compare_results_file_to_reference",
+            "src.validation.compare_results_file_to_reference",
             return_value=_METRICS,
         ) as mock_crf:
             validate_predictions(
@@ -82,7 +82,7 @@ class TestValidatePredictions:
 
     def test_propagates_file_not_found_error(self):
         with patch(
-            "src.comparative_analysis.compare_results_file_to_reference",
+            "src.validation.compare_results_file_to_reference",
             side_effect=FileNotFoundError("Results file not found"),
         ):
             with pytest.raises(FileNotFoundError):
@@ -90,7 +90,7 @@ class TestValidatePredictions:
 
     def test_returns_metrics_dict(self):
         with patch(
-            "src.comparative_analysis.compare_results_file_to_reference",
+            "src.validation.compare_results_file_to_reference",
             return_value=_METRICS,
         ):
             result = validate_predictions("results/NC_TEST_predictions.gff", genome_id="NC_TEST")
@@ -99,6 +99,33 @@ class TestValidatePredictions:
         assert "sensitivity" in result
         assert "precision" in result
         assert "f1_score" in result
+
+    def test_genome_id_stripped_of_predictions_suffix(self):
+        """Stem 'NC_000913.3_predictions' → genome_id 'NC_000913.3'."""
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            return_value=_METRICS,
+        ) as mock_crf:
+            validate_predictions("results/NC_000913.3_predictions.gff")
+
+        mock_crf.assert_called_once_with("NC_000913.3")
+
+    def test_propagates_value_error(self):
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            side_effect=ValueError("bad coords"),
+        ):
+            with pytest.raises(ValueError):
+                validate_predictions("results/NC_TEST_predictions.gff", genome_id="NC_TEST")
+
+    def test_called_exactly_once(self):
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            return_value=_METRICS,
+        ) as mock_crf:
+            validate_predictions("results/NC_TEST_predictions.gff", genome_id="NC_TEST")
+
+        assert mock_crf.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -123,9 +150,29 @@ class TestPrintValidationReport:
     def test_outputs_tp_fp_fn_counts(self, capsys):
         print_validation_report(_METRICS)
         output = capsys.readouterr().out
-        assert "7" in output   # TP
-        assert "1" in output   # FP
-        assert "3" in output   # FN
+        assert "7" in output  # TP
+        assert "1" in output  # FP
+        assert "3" in output  # FN
+
+    def test_outputs_genome_id(self, capsys):
+        print_validation_report(_METRICS)
+        output = capsys.readouterr().out
+        assert "NC_TEST" in output
+
+    def test_outputs_precision_value(self, capsys):
+        print_validation_report(_METRICS)
+        output = capsys.readouterr().out
+        assert "87.50" in output or "0.875" in output or "87%" in output or "Precision" in output
+
+    def test_outputs_reference_count(self, capsys):
+        print_validation_report(_METRICS)
+        output = capsys.readouterr().out
+        assert "10" in output  # reference_count
+
+    def test_outputs_predicted_count(self, capsys):
+        print_validation_report(_METRICS)
+        output = capsys.readouterr().out
+        assert "8" in output  # predicted_count
 
 
 # ---------------------------------------------------------------------------
@@ -134,9 +181,9 @@ class TestPrintValidationReport:
 
 
 class TestValidateFromResultsDirectory:
-    def test_constructs_correct_pred_path(self):
+    def test_calls_compare_with_correct_genome_id(self):
         with patch(
-            "src.comparative_analysis.compare_results_file_to_reference",
+            "src.validation.compare_results_file_to_reference",
             return_value=_METRICS,
         ) as mock_crf:
             validate_from_results_directory("NC_TEST")
@@ -145,9 +192,321 @@ class TestValidateFromResultsDirectory:
 
     def test_returns_metrics_dict(self):
         with patch(
-            "src.comparative_analysis.compare_results_file_to_reference",
+            "src.validation.compare_results_file_to_reference",
             return_value=_METRICS,
         ):
             result = validate_from_results_directory("NC_TEST")
 
         assert result == _METRICS
+
+    def test_returns_dict_with_sensitivity_key(self):
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            return_value=_METRICS,
+        ):
+            result = validate_from_results_directory("NC_TEST")
+
+        assert "sensitivity" in result
+
+    def test_returns_dict_with_f1_key(self):
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            return_value=_METRICS,
+        ):
+            result = validate_from_results_directory("NC_TEST")
+
+        assert "f1_score" in result
+
+    def test_propagates_file_not_found(self):
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            side_effect=FileNotFoundError("missing"),
+        ):
+            with pytest.raises(FileNotFoundError):
+                validate_from_results_directory("NC_MISSING")
+
+    def test_called_exactly_once(self):
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            return_value=_METRICS,
+        ) as mock_crf:
+            validate_from_results_directory("NC_TEST")
+
+        assert mock_crf.call_count == 1
+
+    def test_different_genome_id_passes_correctly(self):
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            return_value=_METRICS,
+        ) as mock_crf:
+            validate_from_results_directory("NC_000913.3")
+
+        mock_crf.assert_called_once_with("NC_000913.3")
+
+    def test_result_has_no_missing_core_keys(self):
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            return_value=_METRICS,
+        ):
+            result = validate_from_results_directory("NC_TEST")
+
+        for key in ("sensitivity", "precision", "f1_score", "true_positives"):
+            assert key in result, f"Missing key: {key}"
+
+
+# ===========================================================================
+# Tests: validate_batch()
+# ===========================================================================
+
+
+class TestValidateBatch:
+    """Tests for the per-taxonomy batch validation function.
+
+    Uses a fixture of 6 synthetic genomes across 3 groups so every
+    aggregation path (single-genome group, multi-genome group, overall,
+    flag threshold) is exercised.
+    """
+
+    # ── Six synthetic metric dicts ────────────────────────────────────────
+    # Proteobacteria: NC_A (good), NC_B (good)
+    # Archaea:        NC_C (poor — should trigger the flag)
+    # Firmicutes:     NC_D, NC_E, NC_F (mixed)
+
+    _MAKE = staticmethod(
+        lambda acc, sens, prec, f1: {
+            "genome_id": acc,
+            "results_file": f"results/{acc}_predictions.gff",
+            "reference_file": f"ref/{acc}.gff",
+            "reference_count": 100,
+            "predicted_count": 90,
+            "true_positives": int(sens * 100),
+            "false_positives": 90 - int(sens * 100),
+            "false_negatives": 100 - int(sens * 100),
+            "sensitivity": sens,
+            "precision": prec,
+            "f1_score": f1,
+        }
+    )
+
+    @classmethod
+    def _all_metrics(cls):
+        return {
+            "NC_A": cls._MAKE("NC_A", 0.85, 0.90, 0.874),
+            "NC_B": cls._MAKE("NC_B", 0.80, 0.88, 0.838),
+            "NC_C": cls._MAKE("NC_C", 0.35, 0.60, 0.441),  # poor — Archaea
+            "NC_D": cls._MAKE("NC_D", 0.75, 0.82, 0.784),
+            "NC_E": cls._MAKE("NC_E", 0.78, 0.85, 0.814),
+            "NC_F": cls._MAKE("NC_F", 0.72, 0.80, 0.758),
+        }
+
+    _GROUP_MAP = {
+        "NC_A": "Proteobacteria",
+        "NC_B": "Proteobacteria",
+        "NC_C": "Archaea",
+        "NC_D": "Firmicutes",
+        "NC_E": "Firmicutes",
+        "NC_F": "Firmicutes",
+    }
+
+    _ACCESSIONS = list(_GROUP_MAP.keys())
+
+    # ── Structure ─────────────────────────────────────────────────────────
+
+    def test_returns_required_top_level_keys(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        assert set(r.keys()) == {"per_genome", "per_group", "overall"}
+
+    def test_per_genome_has_all_accessions(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        assert set(r["per_genome"].keys()) == set(self._ACCESSIONS)
+
+    def test_per_genome_contains_group_field(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        for acc, grp in self._GROUP_MAP.items():
+            assert r["per_genome"][acc]["group"] == grp
+
+    # ── Per-group counts and averages ─────────────────────────────────────
+
+    def test_per_group_n_counts_correct(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        assert r["per_group"]["Proteobacteria"]["n"] == 2
+        assert r["per_group"]["Archaea"]["n"] == 1
+        assert r["per_group"]["Firmicutes"]["n"] == 3
+
+    def test_per_group_sensitivity_is_mean_of_members(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        # Proteobacteria: mean(85, 80) = 82.5
+        assert r["per_group"]["Proteobacteria"]["sensitivity"] == pytest.approx(82.5, abs=0.1)
+        # Firmicutes: mean(75, 78, 72) = 75
+        assert r["per_group"]["Firmicutes"]["sensitivity"] == pytest.approx(75.0, abs=0.1)
+
+    def test_per_group_f1_correct(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        prot_f1 = r["per_group"]["Proteobacteria"]["f1_score"]
+        assert 80.0 < prot_f1 < 90.0  # sanity range for good genomes
+
+    # ── Overall aggregation ───────────────────────────────────────────────
+
+    def test_overall_n_equals_successful_genome_count(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        assert r["overall"]["n"] == len(self._ACCESSIONS)
+
+    def test_overall_sensitivity_is_macro_average(self):
+        """Overall sensitivity = mean of all per-genome sensitivities."""
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        expected = (85 + 80 + 35 + 75 + 78 + 72) / 6
+        assert r["overall"]["sensitivity"] == pytest.approx(expected, abs=0.1)
+
+    # ── Robustness ───────────────────────────────────────────────────────
+
+    def test_failed_genome_skipped_others_still_reported(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+
+        def _side(acc):
+            if acc == "NC_C":
+                raise FileNotFoundError("results not found")
+            return m[acc]
+
+        with patch("src.validation.compare_results_file_to_reference", side_effect=_side):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        assert "NC_C" not in r["per_genome"]
+        assert "Archaea" not in r["per_group"]  # only genome in group skipped
+        assert r["overall"]["n"] == len(self._ACCESSIONS) - 1
+
+    def test_all_failed_returns_zero_overall(self):
+        from src.validation import validate_batch
+
+        with patch(
+            "src.validation.compare_results_file_to_reference",
+            side_effect=FileNotFoundError("not found"),
+        ):
+            r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        assert r["overall"]["n"] == 0
+        assert r["per_genome"] == {}
+
+    def test_empty_accession_list_returns_empty(self):
+        from src.validation import validate_batch
+
+        with patch("src.validation.compare_results_file_to_reference"):
+            r = validate_batch([], group_map={})
+
+        assert r["overall"]["n"] == 0
+        assert r["per_group"] == {}
+
+    def test_unknown_accession_falls_back_to_unknown_group(self):
+        """Accession not in group_map → assigned group 'Unknown'."""
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(["NC_A"], group_map={})  # empty map → Unknown
+
+        assert r["per_genome"]["NC_A"]["group"] == "Unknown"
+        assert "Unknown" in r["per_group"]
+
+    def test_single_genome_overall_equals_that_genome(self):
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            r = validate_batch(["NC_A"], group_map={"NC_A": "Proteobacteria"})
+
+        assert r["overall"]["sensitivity"] == pytest.approx(85.0, abs=0.1)
+        assert r["overall"]["n"] == 1
+
+    def test_flagging_threshold_marks_poor_group(self):
+        """Archaea (35% sens) should be flagged as >5 pp below overall."""
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            import contextlib
+            import io
+
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                r = validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        overall_f1 = r["overall"]["f1_score"]
+        archaea_f1 = r["per_group"]["Archaea"]["f1_score"]
+        assert archaea_f1 < overall_f1 - 5.0  # would trigger the flag
+
+    def test_low_n_warning_printed_when_group_below_10(self):
+        """Groups with n < 10 must emit a statistically-motivated warning."""
+        import contextlib
+        import io
+
+        from src.validation import validate_batch
+
+        m = self._all_metrics()
+        with patch("src.validation.compare_results_file_to_reference", side_effect=lambda a: m[a]):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                validate_batch(self._ACCESSIONS, group_map=self._GROUP_MAP)
+
+        output = buf.getvalue()
+        # All groups in the fixture have n < 10 (max is Firmicutes n=3)
+        assert "Low-n" in output or "n < 10" in output
+
+    def test_no_low_n_warning_when_all_groups_above_threshold(self):
+        """No warning when every group has n >= 10."""
+        import contextlib
+        import io
+
+        from src.validation import validate_batch
+
+        # Build 20 genomes, all Proteobacteria
+        big_map = {f"NC_{i}": "Proteobacteria" for i in range(20)}
+        base = self._all_metrics()["NC_A"]
+
+        with patch("src.validation.compare_results_file_to_reference", return_value=base):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                validate_batch(list(big_map.keys()), group_map=big_map)
+
+        output = buf.getvalue()
+        assert "Low-n" not in output


### PR DESCRIPTION
## Summary

Adds `validate_batch()` — groups validation results by taxon, prints per-group Sens/Prec/F1, and warns when n < 10 (exploratory only) or n < 20 (unreliable for publication claims).

## Statistical warning

With typical within-group std ~10 pp: n<10 → SE ≥ 3 pp. Groups below n=10 are flagged pointing to #101 (rebalance TEST_GENOMES).

## Tests: 40 pass — 8 per class

Closes #104