### PR TITLE
REF: API threshold defaults, __all__ export lists in all src/ modules (#64)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -162,9 +162,9 @@ async def predict_genes(request: PredictionRequest):
 async def predict_genes_from_file(
     file: UploadFile = File(...),
     use_group_ml: bool = True,
-    group_threshold: float = 0.1,
+    group_threshold: float = 0.07,
     use_final_ml: bool = True,
-    final_threshold: float = 0.12,
+    final_threshold: float = 0.25,
 ):
     """
     Predict genes from an uploaded FASTA file

--- a/src/cache.py
+++ b/src/cache.py
@@ -5,6 +5,15 @@ Handles caching of expensive ORF detection operations to speed up analysis.
 Uses data_management for I/O and traditional_methods for ORF detection.
 """
 
+__all__ = [
+    "load_cache",
+    "save_cache",
+    "add_genome_to_cache",
+    "get_cached_genome",
+    "clear_cache",
+    "cache_stats",
+]
+
 import os
 import pickle
 from typing import Dict, List

--- a/src/comparative_analysis.py
+++ b/src/comparative_analysis.py
@@ -7,6 +7,14 @@ This module provides tools for comparing predicted ORFs against reference annota
 - Validation metrics (sensitivity, precision, F1)
 """
 
+__all__ = [
+    "compare_orfs_to_reference",
+    "compare_results_file_to_reference",
+    "analyze_and_plot_scores",
+    "compare_codon_usage",
+    "analyze_non_cds_genes",
+]
+
 from typing import Dict, List, Set
 
 import matplotlib.pyplot as plt

--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,22 @@ Global constants and configuration settings.
 Centralized location for all project-wide constants.
 """
 
+__all__ = [
+    "NCBI_EMAIL",
+    "TEST_GENOMES",
+    "GENOME_CATALOG",
+    "START_CODON_WEIGHTS",
+    "START_SELECTION_WEIGHTS",
+    "FIRST_FILTER_THRESHOLD",
+    "SECOND_FILTER_THRESHOLD",
+    "SCORE_WEIGHTS",
+    "START_CODONS",
+    "STOP_CODONS",
+    "get_genome_by_id",
+    "get_genome_by_accession",
+    "list_genomes_by_group",
+]
+
 # NCBI Configuration
 NCBI_EMAIL = "your_email@example.com"
 

--- a/src/data_management.py
+++ b/src/data_management.py
@@ -22,6 +22,19 @@ Key Functions:
 All downloads are cached - re-running will skip existing files.
 """
 
+__all__ = [
+    "get_project_root",
+    "get_data_dir",
+    "get_gff_path",
+    "get_fasta_path",
+    "download_genome_and_reference",
+    "download_all_test_genomes",
+    "load_genome_sequence",
+    "load_reference_genes_from_gff",
+    "get_reference_orfs_from_gff",
+    "cleanup_generated_files",
+]
+
 import os
 from pathlib import Path
 from typing import Dict, List, Set, Tuple

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -15,6 +15,8 @@ from Bio.SeqUtils.ProtParam import ProteinAnalysis
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["OrfGroupClassifier", "HybridGeneFilter"]
+
 """
 Machine learning classifier for ORF groups.
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -11,6 +11,12 @@ Key Functions:
 - validate_batch(): Run validation across multiple genomes with per-group breakdown
 """
 
+__all__ = [
+    "validate_predictions",
+    "validate_from_results_directory",
+    "validate_batch",
+]
+
 from pathlib import Path
 from typing import Dict, List, Optional
 


### PR DESCRIPTION
## Summary

- `api/main.py`: update `group_threshold` 0.1→0.07 and `final_threshold` 0.12→0.25 to match current production model thresholds
- Add `__all__` export lists to all `src/` modules (`config`, `data_management`, `ml_models`, `validation`, `comparative_analysis`, `cache`) — makes the public API explicit for IDE support and `from src.X import *` safety

## Test plan

- [x] `pytest tests/` — 405 passed
- [x] `flake8 api/ src/` — clean