### PR TITLE
BUG: remove duplicate IMM probability lookup in score_imm_ratio() (#132)

### DIFF
--- a/src/traditional_methods.py
+++ b/src/traditional_methods.py
@@ -1414,8 +1414,6 @@ def score_imm_ratio(
         else:
             coding_prob = get_interpolated_probability(nucleotide, context, 0, coding_id)
             noncoding_prob = get_interpolated_probability(nucleotide, context, 0, noncoding_id)
-            coding_prob = get_interpolated_probability(nucleotide, context, 0, coding_id)
-            noncoding_prob = get_interpolated_probability(nucleotide, context, 0, noncoding_id)
 
         coding_prob = max(coding_prob, EPSILON)
         noncoding_prob = max(noncoding_prob, EPSILON)


### PR DESCRIPTION
## Summary

Removes two duplicate lines in `score_imm_ratio()` (`src/traditional_methods.py`, non-frame-aware branch). Lines 1417–1418 were exact copy-paste duplicates of 1415–1416, immediately overwriting the valid `coding_prob`/`noncoding_prob` with identical values.

## Impact

- **No change in predictions** — the duplicates hit the LRU cache and return the same value, so results are bit-identical (verified: E. coli K-12 still predicts 3,575 genes)
- **Performance**: eliminates two redundant cache lookups per nucleotide in the non-frame-aware IMM path
- 423/423 tests pass

Closes #132