### PR TITLE
BUG: use old_hf.threshold from artifact instead of hardcoded 0.12 (#134)

### DIFF
--- a/scripts/train_hybrid.py
+++ b/scripts/train_hybrid.py
@@ -270,20 +270,23 @@ if test_cands is not None and test_labels is not None and PROD_MODEL.exists():
     with contextlib.redirect_stdout(io.StringIO()):
         old_hf.load(str(PROD_MODEL))
 
-    evaluate(old_hf, test_cands, test_labels, "current model (t=0.12)", threshold=0.12)
+    old_t = old_hf.threshold
+    evaluate(old_hf, test_cands, test_labels, f"current model (t={old_t:.3f})", threshold=old_t)
     evaluate(hf, test_cands, test_labels, "new model (calibrated threshold)", threshold=best_t)
-    evaluate(hf, test_cands, test_labels, "new model (t=0.12 for fair compare)", threshold=0.12)
+    evaluate(
+        hf, test_cands, test_labels, f"new model (t={old_t:.3f} for fair compare)", threshold=old_t
+    )
 
     # Threshold sweep
     import numpy as _np
     from sklearn.metrics import recall_score as _rs
 
-    old_hf_thresh = 0.12
+    old_hf_thresh = old_t
     _, old_probs, _ = old_hf.predict(test_cands, batch_size=64)
     _, new_probs, _ = hf.predict(test_cands, batch_size=64)
     old_recall = _rs(test_labels, (old_probs >= old_hf_thresh).astype(int), zero_division=0)
 
-    print(f"\n  Threshold sweep (old recall target at t=0.12: {old_recall:.4f}):")
+    print(f"\n  Threshold sweep (old recall target at t={old_t:.3f}: {old_recall:.4f}):")
     print(
         f"  {'t':>5}  {'OLD F1':>7}  {'OLD Rec':>8}  |  {'NEW F1':>7}  {'NEW Rec':>8}  {'dF1':>7}"
     )

--- a/src/traditional_methods.py
+++ b/src/traditional_methods.py
@@ -1414,8 +1414,6 @@ def score_imm_ratio(
         else:
             coding_prob = get_interpolated_probability(nucleotide, context, 0, coding_id)
             noncoding_prob = get_interpolated_probability(nucleotide, context, 0, noncoding_id)
-            coding_prob = get_interpolated_probability(nucleotide, context, 0, coding_id)
-            noncoding_prob = get_interpolated_probability(nucleotide, context, 0, noncoding_id)
 
         coding_prob = max(coding_prob, EPSILON)
         noncoding_prob = max(noncoding_prob, EPSILON)


### PR DESCRIPTION
## Summary

`scripts/train_hybrid.py` evaluated the production model at a hardcoded threshold of `0.12` during the test-set comparison, even though the model's actual deployed threshold is `0.25` (stored in the artifact). This made the before/after F1 delta meaningless — the old model was being evaluated at an arbitrary non-deployment operating point.

## Fix

Replaced all three occurrences of the hardcoded `0.12` with `old_hf.threshold` (loaded directly from the artifact). The label strings and sweep printout now also reflect the actual threshold value rather than a hardcoded constant.

## Impact

- No change to training logic or model weights
- Test-set comparison now produces a fair apples-to-apples delta
- 423/423 tests pass

Closes #134