### PR TITLE
BUG: standardize metric scale — add _pct fields to both comparison functions (#133)

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -160,9 +160,9 @@ for info in genomes:
     if r is None:
         print("SKIP")
         continue
-    f1 = r["f1_score"]
-    sens = r["sensitivity"]
-    prec = r["precision"]
+    f1 = r["f1_pct"]
+    sens = r["sensitivity_pct"]
+    prec = r["precision_pct"]
     print(f"\r  {acc:<16} {group:<18} {f1:>7.2f} {sens:>7.2f} {prec:>7.2f}")
     results.append(
         {"accession": acc, "group": group, "f1": f1, "sensitivity": sens, "precision": prec}

--- a/src/comparative_analysis.py
+++ b/src/comparative_analysis.py
@@ -528,12 +528,12 @@ def compare_orfs_to_reference(
     false_neg = len(ref) - true_pos
     false_pos = len(pred_coords) - true_pos
 
-    sensitivity = (true_pos / len(ref) * 100) if len(ref) > 0 else 0
-    precision = (true_pos / len(pred_coords) * 100) if len(pred_coords) > 0 else 0
+    sensitivity = (true_pos / len(ref)) if len(ref) > 0 else 0.0
+    precision = (true_pos / len(pred_coords)) if len(pred_coords) > 0 else 0.0
     f1 = (
         (2 * precision * sensitivity / (precision + sensitivity))
         if (precision + sensitivity) > 0
-        else 0
+        else 0.0
     )
 
     match_mode = (
@@ -548,9 +548,9 @@ def compare_orfs_to_reference(
     print(f"False negatives (missed):    {false_neg:,}")
     print(f"False positives (spurious):  {false_pos:,}")
     print()
-    print(f"Sensitivity (Recall):        {sensitivity:.2f}%")
-    print(f"Precision:                   {precision:.2f}%")
-    print(f"F1 Score:                    {f1:.2f}")
+    print(f"Sensitivity (Recall):        {sensitivity:.2%}")
+    print(f"Precision:                   {precision:.2%}")
+    print(f"F1 Score:                    {f1:.4f}")
     print("=" * 80)
 
     return {
@@ -562,6 +562,9 @@ def compare_orfs_to_reference(
         "sensitivity": sensitivity,
         "precision": precision,
         "f1_score": f1,
+        "sensitivity_pct": sensitivity * 100,
+        "precision_pct": precision * 100,
+        "f1_pct": f1 * 100,
         "match_mode": match_mode,
         "start_tolerance": start_tolerance,
         "stop_tolerance": stop_tolerance,
@@ -715,6 +718,9 @@ def compare_results_file_to_reference(genome_id: str) -> Dict:
         "recall": sensitivity,
         "precision": precision,
         "f1_score": f1_score,
+        "sensitivity_pct": sensitivity * 100,
+        "precision_pct": precision * 100,
+        "f1_pct": f1_score * 100,
     }
 
 

--- a/tests/integration/test_pipeline_smoke.py
+++ b/tests/integration/test_pipeline_smoke.py
@@ -22,8 +22,10 @@ REPO_ROOT = Path(__file__).parent.parent.parent
 DATA_DIR = REPO_ROOT / "data" / "full_dataset"
 MODELS_DIR = REPO_ROOT / "models"
 
-# Minimum acceptable F1 on E. coli K-12 — if we drop below this something is wrong
-MIN_F1 = 75.0
+# Minimum acceptable thresholds on E. coli K-12 (0.0–1.0 fractions)
+MIN_F1 = 0.75
+MIN_SENSITIVITY = 0.60
+MIN_PRECISION = 0.80
 SMOKE_GENOME = "NC_000913.3"
 
 
@@ -122,19 +124,19 @@ class TestPipelineSmoke:
         """F1 score must be above the minimum acceptable threshold."""
         f1 = pipeline_output["metrics"]["f1_score"]
         assert f1 >= MIN_F1, (
-            f"Pipeline F1 {f1:.2f}% is below minimum {MIN_F1}%. "
+            f"Pipeline F1 {f1:.2%} is below minimum {MIN_F1:.0%}. "
             "A model or code change may have broken the pipeline."
         )
 
     def test_sensitivity_above_minimum(self, pipeline_output):
         """Sensitivity must be above 60% — catching fewer than that is a red flag."""
         sens = pipeline_output["metrics"]["sensitivity"]
-        assert sens >= 60.0, f"Sensitivity {sens:.2f}% is below 60%"
+        assert sens >= MIN_SENSITIVITY, f"Sensitivity {sens:.2%} is below {MIN_SENSITIVITY:.0%}"
 
     def test_precision_above_minimum(self, pipeline_output):
         """Precision must be above 80% — predicting mostly false genes is a red flag."""
         prec = pipeline_output["metrics"]["precision"]
-        assert prec >= 80.0, f"Precision {prec:.2f}% is below 80%"
+        assert prec >= MIN_PRECISION, f"Precision {prec:.2%} is below {MIN_PRECISION:.0%}"
 
     def test_all_predictions_in_genome_bounds(self, pipeline_output):
         """Every predicted gene must be within the genome sequence boundaries."""

--- a/tests/test_comparative_analysis.py
+++ b/tests/test_comparative_analysis.py
@@ -64,9 +64,12 @@ class TestCompareOrfsToReference:
         assert result["true_positives"] == 3
         assert result["false_negatives"] == 0
         assert result["false_positives"] == 0
-        assert result["sensitivity"] == pytest.approx(100.0)
-        assert result["precision"] == pytest.approx(100.0)
-        assert result["f1_score"] == pytest.approx(100.0)
+        assert result["sensitivity"] == pytest.approx(1.0)
+        assert result["precision"] == pytest.approx(1.0)
+        assert result["f1_score"] == pytest.approx(1.0)
+        assert result["sensitivity_pct"] == pytest.approx(100.0)
+        assert result["precision_pct"] == pytest.approx(100.0)
+        assert result["f1_pct"] == pytest.approx(100.0)
 
     def test_no_overlap_gives_zero_sensitivity_and_precision(self, tmp_path):
         gff = _make_gff_file(tmp_path)
@@ -93,18 +96,18 @@ class TestCompareOrfsToReference:
         assert result["false_negatives"] == 1  # (900, 1100) was missed
 
     def test_sensitivity_formula(self, tmp_path):
-        """Sensitivity = TP / reference_count * 100."""
+        """Sensitivity = TP / reference_count, returned as 0.0–1.0 fraction."""
         gff = _make_gff_file(tmp_path)
         orfs = _orfs_from_coords([(100, 300)])  # 1 of 3 reference genes
 
         with patch("src.comparative_analysis.get_gff_path", return_value=gff):
             result = compare_orfs_to_reference(orfs, "NC_TEST")
 
-        expected = 1 / 3 * 100
-        assert result["sensitivity"] == pytest.approx(expected)
+        assert result["sensitivity"] == pytest.approx(1 / 3)
+        assert result["sensitivity_pct"] == pytest.approx(1 / 3 * 100)
 
     def test_precision_formula(self, tmp_path):
-        """Precision = TP / predicted_count * 100."""
+        """Precision = TP / predicted_count, returned as 0.0–1.0 fraction."""
         gff = _make_gff_file(tmp_path)
         # predict 1 correct + 1 wrong out of 2 predictions
         orfs = _orfs_from_coords([(100, 300), (9999, 10000)])
@@ -112,8 +115,8 @@ class TestCompareOrfsToReference:
         with patch("src.comparative_analysis.get_gff_path", return_value=gff):
             result = compare_orfs_to_reference(orfs, "NC_TEST")
 
-        expected = 1 / 2 * 100
-        assert result["precision"] == pytest.approx(expected)
+        assert result["precision"] == pytest.approx(1 / 2)
+        assert result["precision_pct"] == pytest.approx(1 / 2 * 100)
 
     def test_f1_formula(self, tmp_path):
         """F1 = 2 * P * S / (P + S)."""


### PR DESCRIPTION
## Summary

Fixes the metric scale inconsistency between the two comparison functions:

| Function | Before | After |
|---|---|---|
| `compare_orfs_to_reference()` | sensitivity/precision/f1 as **0–100** | 0.0–1.0 + `_pct` fields |
| `compare_results_file_to_reference()` | sensitivity/precision/f1 as **0.0–1.0** | 0.0–1.0 + `_pct` fields |

Both functions now return **both** representations:
- `sensitivity`, `precision`, `f1_score` → 0.0–1.0 (standard scientific scale)
- `sensitivity_pct`, `precision_pct`, `f1_pct` → 0–100 (for display)

## Files changed

- `src/comparative_analysis.py` — standardized to fractions, added `_pct` fields, updated print format to `{:.2%}`
- `scripts/benchmark.py` — display now uses `_pct` fields (output is unchanged visually)
- `tests/test_comparative_analysis.py` — updated assertions from 0–100 to 0.0–1.0, added `_pct` field assertions
- `tests/integration/test_pipeline_smoke.py` — updated `MIN_F1 = 75.0 → 0.75`, sensitivity/precision thresholds match

## Test plan

- [x] 423/423 tests pass
- [x] No behaviour change in benchmark output (still displays percentages via `_pct`)

Closes #133