### PR TITLE
TST: fill test gaps for issues #147–#152

### DIFF
--- a/tests/integration/test_pipeline_smoke.py
+++ b/tests/integration/test_pipeline_smoke.py
@@ -185,3 +185,24 @@ class TestPipelineSmoke:
             "false_negatives",
         ):
             assert key in metrics, f"Missing key: {key}"
+
+
+# ── Standalone regression tests ────────────────────────────────────────────────
+
+
+@pytest.mark.xfail(
+    reason="issue #152: load_models silently returns None for missing files; "
+    "should raise a clear FileNotFoundError or RuntimeError"
+)
+def test_load_models_missing_file_raises_clear_error_issue_152(tmp_path):
+    # Regression for #152: passing a non-existent model path must raise a
+    # clear, actionable exception (not silently return None or produce a bare
+    # pickle/AttributeError downstream).
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from src.pipeline import load_models
+
+    with pytest.raises((FileNotFoundError, RuntimeError, OSError)) as exc_info:
+        load_models(lgb_path=str(tmp_path / "missing.pkl"))
+    assert "missing.pkl" in str(exc_info.value) or "not found" in str(exc_info.value).lower()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,9 +13,9 @@ exercised here — those belong in integration tests.  These tests cover:
 - 404 / error responses for missing resources
 """
 
+import httpx
 import pytest
 import pytest_asyncio
-import httpx
 
 from api.main import app
 
@@ -131,9 +131,21 @@ class TestPredictValidation:
         assert r.status_code == 422
 
     async def test_non_json_body_returns_422(self, ac):
-        r = await ac.post("/predict", content=b"not json",
-                          headers={"Content-Type": "application/json"})
+        r = await ac.post(
+            "/predict", content=b"not json", headers={"Content-Type": "application/json"}
+        )
         assert r.status_code == 422
+
+    @pytest.mark.xfail(
+        reason="issue #151: invalid nucleotides return 500 until issue #135 is fixed"
+    )
+    async def test_invalid_nucleotides_returns_400_issue_151(self, ac):
+        # Regression for #151: a sequence with non-nucleotide characters must
+        # return 400 with a descriptive message, not a generic 500.
+        r = await ac.post("/predict", json={"sequence": "AAA@#$INVALID"})
+        assert r.status_code == 400
+        detail = r.json()["detail"].lower()
+        assert "invalid" in detail or "nucleotide" in detail or "fasta" in detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_comparative_analysis.py
+++ b/tests/test_comparative_analysis.py
@@ -190,6 +190,23 @@ class TestCompareOrfsToReference:
         }
         assert required <= set(result.keys())
 
+    @pytest.mark.xfail(
+        reason="issue #149: empty predictions should return zero metrics, not raise ValueError"
+    )
+    def test_empty_predictions_returns_zero_metrics_issue_149(self, tmp_path):
+        # Desired behaviour for #149: when no ORFs are predicted the function
+        # should return {sensitivity: 0.0, precision: 0.0, f1_score: 0.0}
+        # instead of raising ValueError (precision denominator = 0).
+        gff = _make_gff_file(tmp_path)
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            result = compare_orfs_to_reference([], "NC_TEST")
+        assert result["sensitivity"] == 0.0
+        assert result["precision"] == 0.0
+        assert result["f1_score"] == 0.0
+        for v in result.values():
+            if isinstance(v, float):
+                assert v == v, f"NaN in result: {result}"
+
 
 # ---------------------------------------------------------------------------
 # compare_orfs_to_reference — fuzzy coordinate matching (issue #99)

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -263,6 +263,18 @@ class TestHybridGeneFilterPredict:
         assert len(probs) == 0
         assert len(gene_ids) == 0
 
+    def test_empty_list_return_types_are_1d_issue_150(self):
+        # Regression for #150: empty input must return 1-D arrays (shape (0,))
+        # not 2-D arrays (shape (0, 1)) which would silently break unpacking.
+        import numpy as np
+
+        hgf = HybridGeneFilter()
+        hgf.model = MagicMock()
+        preds, probs, gene_ids = hgf.predict([], genome_id="test")
+        for arr in (preds, probs):
+            if isinstance(arr, np.ndarray):
+                assert arr.ndim == 1, f"Expected 1-D, got shape {arr.shape}"
+
     def test_raises_value_error_on_missing_features_issue_47(self, synthetic_candidate):
         """
         Regression for issue #47: predict() silently constructed a feature

--- a/tests/test_traditional_methods.py
+++ b/tests/test_traditional_methods.py
@@ -193,6 +193,15 @@ class TestPredictRbsSimple:
         result = predict_rbs_simple(short_seq, {"start": 2})
         assert result["rbs_score"] == -5.0
 
+    def test_no_sd_motif_upstream_yields_low_rbs_score_issue_148(self):
+        # Regression for #148: when the upstream region is all pyrimidines
+        # (zero purines, no SD-like motif), rbs_score must be non-positive —
+        # the no-RBS-found sentinel (-5.0) must not produce a false positive.
+        # 40 C's before ATG: no AGGAGG, no purine-rich region possible.
+        seq = "C" * 40 + "ATG" + "CAG" * 32 + "TAA"
+        result = predict_rbs_simple(seq, {"start": 41})
+        assert result["rbs_score"] <= 0.0
+
 
 # ===========================================================================
 # Tests: build_codon_model()
@@ -1005,6 +1014,17 @@ class TestNormalizeAllOrfScores:
         originals = [o["codon_score"] for o in orfs]
         result = normalize_all_orf_scores(orfs)
         assert list(result["codon_score"]) == originals
+
+    def test_zero_std_one_column_does_not_nan_others_issue_147(self):
+        # Regression for #147: when one score component has std=0 (all identical),
+        # normalizing it to zero must not produce NaN in any other column.
+        orfs = [_make_scored_orf(codon=2.5, imm=float(i), rbs=1.0) for i in range(5)]
+        result = normalize_all_orf_scores(orfs)
+        assert len(result) == 5
+        assert (result["codon_score_norm"] == 0.0).all()
+        assert not result["imm_score_norm"].isna().any()
+        assert not result["rbs_score_norm"].isna().any()
+        assert (result["codon_score"] == 2.5).all()  # raw score unchanged
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Closes #147, #148, #150 (tests added and passing)
- Tracks #149, #151, #152 (xfail — document desired behaviour, unblock once underlying bugs are fixed)

## Changes

| Issue | File | Status |
|-------|------|--------|
| #147 `normalize_all_orf_scores` zero-std preserves other cols | `test_traditional_methods.py` | ✅ pass |
| #148 `predict_rbs_simple` all-pyrimidine upstream | `test_traditional_methods.py` | ✅ pass (assertion fixed: `<= 0.0`) |
| #149 `compare_orfs_to_reference` empty list → zero metrics | `test_comparative_analysis.py` | `xfail` (currently raises `ValueError`) |
| #150 `HybridGeneFilter.predict([])` returns 1-D arrays | `test_ml_models.py` | ✅ pass |
| #151 POST `/predict` invalid nucleotides → 400 | `test_api.py` | `xfail` (needs #135) |
| #152 `load_models` missing file raises clear error | `test_pipeline_smoke.py` | `xfail` (currently returns `None` silently) |

## Test plan

- [ ] `pytest tests/test_traditional_methods.py tests/test_ml_models.py tests/test_comparative_analysis.py tests/test_api.py tests/integration/test_pipeline_smoke.py` — expect 3 pass, 3 xfail, 0 fail