### PR TITLE
FIX: implement HybridGeneFilter.train(), calibrate_threshold(), save() (#131)

### DIFF
--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -559,23 +559,34 @@ class HybridGeneFilter:
             val_seq = self._one_hot_encode_dna(val_candidates, max_len=max_len)
             val_y = val_labels_arr
 
+        from tqdm import tqdm
+
         n = len(candidates)
         best_val_f1 = -1.0
         patience_left = 10
         best_state = None
+        num_batches_per_epoch = max((n + batch_size - 1) // batch_size, 1)
 
         print(
             f"  Training HybridGeneFilter: {n} samples, {n_pos} pos, {n_neg} neg, "
-            f"{'focal loss' if focal_loss else f'pos_weight={n_neg/n_pos:.1f}'}"
+            f"{'focal loss' if focal_loss else f'pos_weight={n_neg/n_pos:.1f}'}, "
+            f"device={self.device}"
         )
 
-        for epoch in range(1, epochs + 1):
+        epoch_bar = tqdm(range(1, epochs + 1), desc="  Training", unit="epoch", leave=True)
+        for epoch in epoch_bar:
             self.model.train()
             idx = torch.randperm(n)
             epoch_loss = 0.0
-            num_batches = 0
 
-            for start in range(0, n, batch_size):
+            batch_bar = tqdm(
+                range(0, n, batch_size),
+                desc=f"    epoch {epoch}/{epochs}",
+                unit="batch",
+                total=num_batches_per_epoch,
+                leave=False,
+            )
+            for start in batch_bar:
                 batch_idx = idx[start : start + batch_size]
                 b_seq = X_seq[batch_idx].to(self.device)
                 b_feat = X_feat[batch_idx].to(self.device)
@@ -589,13 +600,13 @@ class HybridGeneFilter:
                 optimizer.step()
 
                 epoch_loss += loss.item()
-                num_batches += 1
+                batch_bar.set_postfix(loss=f"{loss.item():.4f}")
 
                 del b_seq, b_feat, b_y
                 if self.device == "cuda":
                     torch.cuda.empty_cache()
 
-            avg_loss = epoch_loss / max(num_batches, 1)
+            avg_loss = epoch_loss / num_batches_per_epoch
 
             # Validation
             if val_feat is not None:
@@ -614,18 +625,18 @@ class HybridGeneFilter:
                 else:
                     patience_left -= 1
 
-                if epoch % 10 == 0 or epoch == 1:
-                    print(
-                        f"  epoch {epoch:3d}/{epochs}  loss={avg_loss:.4f}  val_f1={val_f1:.4f}"
-                        f"  best={best_val_f1:.4f}  patience={patience_left}"
-                    )
+                epoch_bar.set_postfix(
+                    loss=f"{avg_loss:.4f}",
+                    val_f1=f"{val_f1:.4f}",
+                    best=f"{best_val_f1:.4f}",
+                    pat=patience_left,
+                )
 
                 if patience_left == 0:
-                    print(f"  Early stopping at epoch {epoch}.")
+                    print(f"\n  Early stopping at epoch {epoch} (best val_f1={best_val_f1:.4f}).")
                     break
             else:
-                if epoch % 10 == 0 or epoch == 1:
-                    print(f"  epoch {epoch:3d}/{epochs}  loss={avg_loss:.4f}")
+                epoch_bar.set_postfix(loss=f"{avg_loss:.4f}")
 
         # Restore best checkpoint when validation was used
         if best_state is not None:

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -499,8 +499,186 @@ class HybridGeneFilter:
 
         self.model = model
         self.threshold = data["threshold"]
+        if "feature_names" in data:
+            self.feature_names = data["feature_names"]
 
         logger.info("Loaded hybrid model from %s", {model_path})
+
+    def train(
+        self,
+        candidates: List[Dict],
+        labels: np.ndarray,
+        val_candidates: Optional[List[Dict]] = None,
+        val_labels: Optional[np.ndarray] = None,
+        epochs: int = 50,
+        batch_size: int = 64,
+        focal_loss: bool = False,
+    ) -> None:
+        """Train HybridGenePredictor from candidate dicts and binary labels.
+
+        Handles class imbalance via pos_weight (BCEWithLogitsLoss) or focal
+        loss.  Runs early stopping on validation F1 with patience=10.
+        """
+        from sklearn.metrics import f1_score as _f1
+
+        labels = np.asarray(labels, dtype=np.float32)
+        n_pos = int(labels.sum())
+        n_neg = int(len(labels) - n_pos)
+        if n_pos == 0:
+            raise ValueError("Training set has no positive examples.")
+
+        # Extract features and sequences once
+        df_train = self.extract_features(candidates)
+        X_feat = torch.tensor(df_train[self.feature_names].values, dtype=torch.float32)
+        max_len = min(max((len(c.get("sequence", "")) for c in candidates), default=300), 1500)
+        X_seq = self._one_hot_encode_dna(candidates, max_len=max_len)
+        y = torch.tensor(labels, dtype=torch.float32)
+
+        num_features = len(self.feature_names)
+        self.model = HybridGenePredictor(num_traditional_features=num_features)
+        self.model.to(self.device)
+
+        optimizer = torch.optim.Adam(self.model.parameters(), lr=1e-3, weight_decay=1e-4)
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, patience=5, factor=0.5)
+        pos_weight = torch.tensor([n_neg / n_pos], dtype=torch.float32).to(self.device)
+
+        def _loss_fn(logits, targets):
+            if focal_loss:
+                # Focal loss: -alpha*(1-p)^gamma * log(p)
+                bce = F.binary_cross_entropy_with_logits(logits, targets, reduction="none")
+                p_t = torch.exp(-bce)
+                return (0.25 * (1 - p_t) ** 2 * bce).mean()
+            return F.binary_cross_entropy_with_logits(logits, targets, pos_weight=pos_weight)
+
+        # Validation tensors (extracted once)
+        val_feat, val_seq, val_y = None, None, None
+        if val_candidates is not None and val_labels is not None:
+            val_labels_arr = np.asarray(val_labels, dtype=np.float32)
+            df_val = self.extract_features(val_candidates)
+            val_feat = torch.tensor(df_val[self.feature_names].values, dtype=torch.float32)
+            val_seq = self._one_hot_encode_dna(val_candidates, max_len=max_len)
+            val_y = val_labels_arr
+
+        n = len(candidates)
+        best_val_f1 = -1.0
+        patience_left = 10
+        best_state = None
+
+        print(
+            f"  Training HybridGeneFilter: {n} samples, {n_pos} pos, {n_neg} neg, "
+            f"{'focal loss' if focal_loss else f'pos_weight={n_neg/n_pos:.1f}'}"
+        )
+
+        for epoch in range(1, epochs + 1):
+            self.model.train()
+            idx = torch.randperm(n)
+            epoch_loss = 0.0
+            num_batches = 0
+
+            for start in range(0, n, batch_size):
+                batch_idx = idx[start : start + batch_size]
+                b_seq = X_seq[batch_idx].to(self.device)
+                b_feat = X_feat[batch_idx].to(self.device)
+                b_y = y[batch_idx].to(self.device)
+
+                optimizer.zero_grad()
+                logits = self.model(b_seq, b_feat)
+                loss = _loss_fn(logits, b_y)
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
+                optimizer.step()
+
+                epoch_loss += loss.item()
+                num_batches += 1
+
+                del b_seq, b_feat, b_y
+                if self.device == "cuda":
+                    torch.cuda.empty_cache()
+
+            avg_loss = epoch_loss / max(num_batches, 1)
+
+            # Validation
+            if val_feat is not None:
+                self.model.eval()
+                with torch.no_grad():
+                    v_logits = self.model(val_seq.to(self.device), val_feat.to(self.device))
+                    v_probs = torch.sigmoid(v_logits).cpu().numpy()
+                val_preds = (v_probs >= 0.5).astype(int)
+                val_f1 = float(_f1(val_y, val_preds, zero_division=0))
+                scheduler.step(1 - val_f1)
+
+                if val_f1 > best_val_f1:
+                    best_val_f1 = val_f1
+                    best_state = {k: v.cpu().clone() for k, v in self.model.state_dict().items()}
+                    patience_left = 10
+                else:
+                    patience_left -= 1
+
+                if epoch % 10 == 0 or epoch == 1:
+                    print(
+                        f"  epoch {epoch:3d}/{epochs}  loss={avg_loss:.4f}  val_f1={val_f1:.4f}"
+                        f"  best={best_val_f1:.4f}  patience={patience_left}"
+                    )
+
+                if patience_left == 0:
+                    print(f"  Early stopping at epoch {epoch}.")
+                    break
+            else:
+                if epoch % 10 == 0 or epoch == 1:
+                    print(f"  epoch {epoch:3d}/{epochs}  loss={avg_loss:.4f}")
+
+        # Restore best checkpoint when validation was used
+        if best_state is not None:
+            self.model.load_state_dict(best_state)
+            print(f"  Restored best checkpoint (val_f1={best_val_f1:.4f})")
+
+        self.model.to(self.device)
+        self.model.eval()
+
+    def calibrate_threshold(
+        self,
+        candidates: List[Dict],
+        labels: np.ndarray,
+    ) -> float:
+        """Sweep decision thresholds and return the one maximising F1.
+
+        Does not mutate self.threshold — caller decides whether to adopt it.
+        """
+        from sklearn.metrics import precision_recall_curve
+
+        labels = np.asarray(labels)
+        _, probs, _ = self.predict(candidates, batch_size=256)
+        precision, recall, thresholds = precision_recall_curve(labels, probs)
+        f1_scores = np.where(
+            (precision + recall) > 0,
+            2 * precision * recall / (precision + recall),
+            0.0,
+        )
+        best_idx = int(np.argmax(f1_scores[:-1]))
+        best_t = float(thresholds[best_idx])
+        best_f1 = float(f1_scores[best_idx])
+        logger.info("Best threshold: %.3f  (val F1=%.4f)", best_t, best_f1)
+        print(f"  Calibrated threshold: {best_t:.3f}  (F1={best_f1:.4f})")
+        return best_t
+
+    def save(self, model_path: str) -> None:
+        """Persist model weights, threshold, and feature list to a pickle file."""
+        import pickle
+
+        if self.model is None:
+            raise RuntimeError("No trained model to save. Call train() first.")
+
+        p = Path(model_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "model_state_dict": self.model.state_dict(),
+            "threshold": float(self.threshold),
+            "num_traditional_features": len(self.feature_names),
+            "feature_names": list(self.feature_names),
+        }
+        with open(p, "wb") as f:
+            pickle.dump(payload, f)
+        logger.info("Saved HybridGeneFilter -> %s", p)
 
     @staticmethod
     def _calculate_enc(sequence: str) -> float:

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -611,3 +611,159 @@ class TestBuildSplits:
         _, val1, test1 = self.build_splits(groups, val_per_group=4, test_per_group=4, seed=1)
         _, val2, test2 = self.build_splits(groups, val_per_group=4, test_per_group=4, seed=2)
         assert val1 != val2 or test1 != test2
+
+
+# ===========================================================================
+# HybridGeneFilter — train / calibrate_threshold / save  (issue #131)
+# ===========================================================================
+
+_SEQ = "ATG" + "CAG" * 30 + "TAA"  # 96 bp synthetic ORF
+_CANDIDATE = {
+    "sequence": _SEQ,
+    "length": len(_SEQ),
+    "start_codon": "ATG",
+    "codon_score_norm": 0.5,
+    "imm_score_norm": 0.5,
+    "rbs_score_norm": 0.5,
+    "length_score_norm": 0.5,
+    "start_score_norm": 0.5,
+    "combined_score": 0.7,
+    "rbs_score": 2.0,
+}
+
+
+def _make_candidates(n: int, rng=None) -> list:
+    """Return n candidate dicts with slightly varied scores."""
+    rng = rng or np.random.default_rng(0)
+    cands = []
+    for _ in range(n):
+        c = dict(_CANDIDATE)
+        c["codon_score_norm"] = float(rng.uniform(0, 1))
+        c["combined_score"] = float(rng.uniform(0, 1))
+        cands.append(c)
+    return cands
+
+
+def _make_binary_labels(n: int, pos_frac: float = 0.2, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    labels = np.zeros(n, dtype=np.float32)
+    pos_idx = rng.choice(n, size=int(n * pos_frac), replace=False)
+    labels[pos_idx] = 1.0
+    return labels
+
+
+class TestHybridGeneFilterTrain:
+    """Unit tests for HybridGeneFilter.train() — issue #131."""
+
+    def test_train_sets_model_attribute(self):
+        hgf = HybridGeneFilter()
+        cands = _make_candidates(40)
+        labels = _make_binary_labels(40, pos_frac=0.25)
+        hgf.train(cands, labels, epochs=2, batch_size=16)
+        assert hgf.model is not None
+
+    def test_train_raises_on_all_negative_labels(self):
+        hgf = HybridGeneFilter()
+        cands = _make_candidates(20)
+        labels = np.zeros(20, dtype=np.float32)
+        with pytest.raises(ValueError, match="no positive examples"):
+            hgf.train(cands, labels, epochs=1)
+
+    def test_trained_model_produces_probabilities_in_unit_interval(self):
+        hgf = HybridGeneFilter()
+        cands = _make_candidates(40)
+        labels = _make_binary_labels(40, pos_frac=0.25)
+        hgf.train(cands, labels, epochs=2, batch_size=16)
+        _, probs, _ = hgf.predict(cands, batch_size=16)
+        assert probs.shape == (40,)
+        assert np.all((probs >= 0.0) & (probs <= 1.0))
+
+    def test_train_with_val_set_runs_without_error(self):
+        hgf = HybridGeneFilter()
+        tr = _make_candidates(40, rng=np.random.default_rng(0))
+        vl = _make_candidates(10, rng=np.random.default_rng(1))
+        hgf.train(
+            tr,
+            _make_binary_labels(40, pos_frac=0.25, seed=0),
+            val_candidates=vl,
+            val_labels=_make_binary_labels(10, pos_frac=0.3, seed=1),
+            epochs=3,
+            batch_size=16,
+        )
+        assert hgf.model is not None
+
+    def test_focal_loss_flag_runs_without_error(self):
+        hgf = HybridGeneFilter()
+        cands = _make_candidates(30)
+        labels = _make_binary_labels(30, pos_frac=0.3)
+        hgf.train(cands, labels, epochs=2, batch_size=16, focal_loss=True)
+        assert hgf.model is not None
+
+
+class TestHybridGeneFilterCalibrateThreshold:
+    """Unit tests for HybridGeneFilter.calibrate_threshold() — issue #131."""
+
+    @pytest.fixture(autouse=True)
+    def trained_hgf(self):
+        hgf = HybridGeneFilter()
+        cands = _make_candidates(60)
+        labels = _make_binary_labels(60, pos_frac=0.25)
+        hgf.train(cands, labels, epochs=3, batch_size=16)
+        self.hgf = hgf
+        self.cands = cands
+        self.labels = labels
+
+    def test_returns_float_in_unit_interval(self):
+        t = self.hgf.calibrate_threshold(self.cands, self.labels)
+        assert isinstance(t, float)
+        assert 0.0 < t < 1.0
+
+    def test_does_not_mutate_threshold_attribute(self):
+        original = self.hgf.threshold
+        self.hgf.calibrate_threshold(self.cands, self.labels)
+        assert self.hgf.threshold == original
+
+
+class TestHybridGeneFilterSave:
+    """Unit tests for HybridGeneFilter.save() / load() round-trip — issue #131."""
+
+    def _trained(self) -> HybridGeneFilter:
+        hgf = HybridGeneFilter()
+        cands = _make_candidates(40)
+        labels = _make_binary_labels(40, pos_frac=0.25)
+        hgf.train(cands, labels, epochs=2, batch_size=16)
+        return hgf
+
+    def test_save_creates_file(self, tmp_path):
+        hgf = self._trained()
+        path = tmp_path / "model.pkl"
+        hgf.save(str(path))
+        assert path.exists()
+
+    def test_save_raises_when_not_trained(self, tmp_path):
+        hgf = HybridGeneFilter()
+        with pytest.raises(RuntimeError, match="train()"):
+            hgf.save(str(tmp_path / "model.pkl"))
+
+    def test_load_restores_threshold(self, tmp_path):
+        hgf = self._trained()
+        hgf.threshold = 0.42
+        path = tmp_path / "model.pkl"
+        hgf.save(str(path))
+
+        hgf2 = HybridGeneFilter()
+        hgf2.load(str(path))
+        assert hgf2.threshold == pytest.approx(0.42)
+
+    def test_load_roundtrip_preserves_predictions(self, tmp_path):
+        cands = _make_candidates(20)
+        hgf = self._trained()
+        path = tmp_path / "model.pkl"
+        hgf.save(str(path))
+
+        hgf2 = HybridGeneFilter()
+        hgf2.load(str(path))
+
+        _, probs1, _ = hgf.predict(cands, batch_size=16)
+        _, probs2, _ = hgf2.predict(cands, batch_size=16)
+        np.testing.assert_allclose(probs1, probs2, rtol=1e-5)


### PR DESCRIPTION
## Summary

Closes #131. `scripts/train_hybrid.py` was raising `AttributeError` immediately because `HybridGeneFilter` had no `train()`, `calibrate_threshold()`, or `save()` methods. The model could not be retrained at all.

## What was added

| Method | Behaviour |
|---|---|
| `train(candidates, labels, ...)` | PyTorch loop — BCEWithLogitsLoss + pos_weight (or focal loss), early stopping (patience=10) on val F1, gradient clipping, `ReduceLROnPlateau` |
| `calibrate_threshold(candidates, labels)` | Precision-recall sweep, returns best-F1 threshold — does **not** mutate `self.threshold` |
| `save(model_path)` | Pickles `{model_state_dict, threshold, num_traditional_features, feature_names}` |

`load()` updated to restore `feature_names` from the pickle so a save/load round-trip uses the exact same feature set.

## Production model safety

`save()` is path-agnostic. `train_hybrid.py` writes to `models/hybrid_best_model_v2.pkl` and requires an explicit `promote` subcommand to replace `models/hybrid_best_model.pkl`. The production model is never touched automatically.

## Test plan

- [x] 11 new unit tests — `TestHybridGeneFilterTrain`, `TestHybridGeneFilterCalibrateThreshold`, `TestHybridGeneFilterSave`
- [x] Full `test_ml_models.py` suite: 70 passed, 0 failed
- [x] No regressions in the rest of the test suite