### PR TITLE
ML: feature engineering for LGB and HybridGeneFilter (#123–#127)

### DIFF
--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -110,7 +110,7 @@ class OrfGroupClassifier:
             codon = orf_group["codon_score"].values.astype(np.float64)
             start = orf_group["start_score"].values.astype(np.float64)
             imm = orf_group["imm_score"].values.astype(np.float64)
-            strands = orf_group["strand"].tolist()
+            lengths = orf_group["length"].values.astype(np.float64)
 
             if weights is not None:
                 cols = orf_group.columns
@@ -177,23 +177,17 @@ class OrfGroupClassifier:
                 "imm_mean": imm.mean(),
                 "start_select_max": max_ss,
                 "start_select_mean": ss.mean(),
-                "strand_plus_frac": strands.count("forward") / n,
-                "strand_minus_frac": strands.count("reverse") / n,
-                # Relative features
+                # Relative-mean features (max variants removed — always 1.0 or redundant)
                 "rel_combined_mean": (
                     combined / max_combined if max_combined > 0 else np.zeros(n)
                 ).mean(),
-                "rel_combined_max": (
-                    combined / max_combined if max_combined > 0 else np.zeros(n)
-                ).max(),
                 "rel_rbs_mean": (rbs / max_rbs if max_rbs > 0 else np.zeros(n)).mean(),
-                "rel_rbs_max": (rbs / max_rbs if max_rbs > 0 else np.zeros(n)).max(),
                 "rel_codon_mean": (codon / max_codon if max_codon > 0 else np.zeros(n)).mean(),
-                "rel_codon_max": (codon / max_codon if max_codon > 0 else np.zeros(n)).max(),
                 "rel_start_mean": (start / max_start if max_start > 0 else np.zeros(n)).mean(),
-                "rel_start_max": (start / max_start if max_start > 0 else np.zeros(n)).max(),
                 "rel_start_select_mean": (ss / max_ss if max_ss > 0 else np.zeros(n)).mean(),
-                "rel_start_select_max": (ss / max_ss if max_ss > 0 else np.zeros(n)).max(),
+                # Biological priors: longest ORF is usually the true gene in nested groups
+                "top_orf_is_longest": int(combined.argmax() == lengths.argmax()),
+                "length_ratio_max_min": float(lengths.max() / max(lengths.min(), 1.0)),
                 "frac_top_combined": (combined >= 0.95 * max_combined).sum() / n,
                 "frac_top_start_select": (ss >= 0.95 * max_ss).sum() / n,
             }
@@ -467,18 +461,20 @@ class HybridGeneFilter:
             "start_score_norm",
             "combined_score",
             "length_bp",
-            "length_codons",
-            "length_log",
+            "length_log",  # length_codons removed (monotone duplicate of length_bp)
             "start_codon_type",
             "stop_codon_type",
-            "has_kozak_like",
+            # has_kozak_like removed (eukaryotic signal, always ~0 in bacteria)
             "gc_content",
+            "gc_deviation",  # orf_gc - genome_gc: better discriminator than absolute GC
+            "gc3_content",  # GC at third codon position: strong coding signal
             "gc_skew",
             "at_skew",
             "purine_content",
             "effective_num_codons",
             "codon_bias_index",
             "has_hairpin_near_stop",
+            "minus10_box_score",  # prokaryotic promoter -10 box (replaces has_kozak_like)
             "hydrophobicity_mean",
             "hydrophobicity_std",
             "charge_mean",
@@ -794,7 +790,58 @@ class HybridGeneFilter:
                 polar_frac=0.0,
             )
 
-    def extract_features(self, candidates: List[Dict], genome_id: str = "unknown") -> pd.DataFrame:
+    @staticmethod
+    def _calculate_gc3(sequence: str) -> float:
+        """GC content at third codon positions — strong coding-region signal."""
+        codons = [sequence[i : i + 3] for i in range(0, len(sequence) - 2, 3)]
+        valid = [c for c in codons if len(c) == 3 and "N" not in c]
+        if not valid:
+            return 0.0
+        return float(sum(1 for c in valid if c[2] in "GC") / len(valid))
+
+    @staticmethod
+    def _score_minus10_box(genome_seq: str, start_1based: int, upstream: int = 50) -> float:
+        """Similarity to TATAAT consensus in the -50 to -25 window upstream of ATG."""
+        if start_1based < upstream + 1:
+            return 0.0
+        region = genome_seq[start_1based - upstream - 1 : start_1based - 25]
+        if not region:
+            return 0.0
+        consensus = "TATAAT"
+        best = 0.0
+        clen = len(consensus)
+        for i in range(len(region) - clen + 1):
+            match = sum(a == b for a, b in zip(region[i:], consensus)) / clen
+            if match > best:
+                best = match
+        return float(best)
+
+    def extract_features(
+        self,
+        candidates: List[Dict],
+        genome_id: str = "unknown",
+        genome_gc: Optional[float] = None,
+        genome_seq: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Extract tabular features from candidate dicts.
+
+        Args:
+            candidates: List of ORF candidate dicts.
+            genome_id: Identifier (used for logging only).
+            genome_gc: Genome-level GC fraction for gc_deviation.  When None,
+                estimated as the mean GC across candidates in this batch.
+            genome_seq: Full genome sequence for minus10_box_score.  When None,
+                the feature defaults to 0.0 (graceful degradation).
+        """
+        # Compute genome_gc proxy if not provided: mean GC across this batch
+        if genome_gc is None and candidates:
+            gc_vals = []
+            for cand in candidates:
+                s = cand.get("sequence", "")
+                if s:
+                    gc_vals.append((s.count("G") + s.count("C")) / max(len(s), 1))
+            genome_gc = float(np.mean(gc_vals)) if gc_vals else 0.5
+
         rows = []
         for candidate in candidates:
             sequence = candidate.get("sequence", "").upper()
@@ -808,7 +855,6 @@ class HybridGeneFilter:
             }
             length = int(candidate.get("length", len(sequence)))
             feature_dict["length_bp"] = float(length)
-            feature_dict["length_codons"] = float(length / 3.0)
             feature_dict["length_log"] = math.log(max(length, 1))
             start_codon = candidate.get(
                 "start_codon", sequence[:3] if len(sequence) >= 3 else "ATG"
@@ -818,20 +864,30 @@ class HybridGeneFilter:
             stop_codon = sequence[-3:] if len(sequence) >= 3 else "TAA"
             stop_map = {"TAA": 0.0, "TAG": 1.0, "TGA": 2.0}
             feature_dict["stop_codon_type"] = float(stop_map.get(stop_codon, 0.0))
-            feature_dict["has_kozak_like"] = float(candidate.get("rbs_score", 0) > 3.0)
             counts = Counter(sequence)
             seq_len = len(sequence)
             g = counts.get("G", 0)
             c = counts.get("C", 0)
             a = counts.get("A", 0)
             t = counts.get("T", 0)
-            feature_dict["gc_content"] = (g + c) / seq_len if seq_len > 0 else 0.0
+            orf_gc = (g + c) / seq_len if seq_len > 0 else 0.0
+            feature_dict["gc_content"] = orf_gc
+            feature_dict["gc_deviation"] = orf_gc - (genome_gc or 0.0)
+            feature_dict["gc3_content"] = self._calculate_gc3(sequence)
             feature_dict["gc_skew"] = (g - c) / (g + c) if (g + c) > 0 else 0.0
             feature_dict["at_skew"] = (a - t) / (a + t) if (a + t) > 0 else 0.0
             feature_dict["purine_content"] = (a + g) / seq_len if seq_len > 0 else 0.0
             feature_dict["effective_num_codons"] = self._calculate_enc(sequence)
             feature_dict["codon_bias_index"] = self._calculate_cbi(sequence)
             feature_dict["has_hairpin_near_stop"] = self._detect_hairpin_near_stop(sequence)
+            # -10 box: use genome_start if genome_seq provided, else 0.0
+            if genome_seq is not None:
+                gstart = int(candidate.get("genome_start", candidate.get("start", 0)))
+                feature_dict["minus10_box_score"] = self._score_minus10_box(
+                    genome_seq, gstart, upstream=50
+                )
+            else:
+                feature_dict["minus10_box_score"] = 0.0
             aa_props = self._calculate_amino_acid_properties(sequence)
             feature_dict.update(
                 {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,7 @@ _BASE_ORF = {
     "start_score": 0.7,
     "imm_score": 0.3,
     "strand": "forward",
+    "length": 300,
     # normalized scores used by start-selection weighting
     "codon_score_norm": 0.6,
     "imm_score_norm": 0.4,

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -24,8 +24,8 @@ from src.ml_models import HybridGeneFilter, OrfGroupClassifier
 # HybridGeneFilter.feature_names — see role_ml_engineer.md for the full list)
 # ---------------------------------------------------------------------------
 
-EXPECTED_LGB_FEATURE_COUNT = 31
-EXPECTED_HYBRID_FEATURE_COUNT = 25
+EXPECTED_LGB_FEATURE_COUNT = 26  # 31 - 7 removed + 2 added (#123, #125)
+EXPECTED_HYBRID_FEATURE_COUNT = 26  # 25 - 2 removed + 3 added (#124, #126, #127)
 
 
 # ===========================================================================
@@ -80,41 +80,24 @@ class TestOrfGroupClassifierFeatureExtraction:
         df = clf.extract_group_features(two_orf_group, genome_id="test")
         assert df.loc[0, "num_orfs"] == 2
 
-    def test_strand_fractions_sum_to_one(self, two_orf_group):
+    def test_top_orf_is_longest_is_binary(self, two_orf_group):
+        # top_orf_is_longest must be 0 or 1 (int boolean)
         clf = OrfGroupClassifier()
         df = clf.extract_group_features(two_orf_group, genome_id="test")
-        total = df.loc[0, "strand_plus_frac"] + df.loc[0, "strand_minus_frac"]
-        assert total == pytest.approx(1.0, abs=1e-6)
+        assert df.loc[0, "top_orf_is_longest"] in (0, 1)
 
-    def test_strand_fractions_use_forward_reverse_labels_issue_97(self, two_orf_group):
-        """Regression #97: strand_plus_frac / strand_minus_frac must use
-        'forward' / 'reverse' labels (not '+' / '-').
-
-        Before the fix both features were always 0.0 because the pipeline
-        stores strand as 'forward'/'reverse' but the code counted '+'/'-'.
-        """
+    def test_length_ratio_max_min_ge_one(self, two_orf_group):
+        # length_ratio_max_min >= 1.0 by definition
         clf = OrfGroupClassifier()
         df = clf.extract_group_features(two_orf_group, genome_id="test")
-        # All ORFs in two_orf_group are on the 'forward' strand (conftest.py)
-        assert df.loc[0, "strand_plus_frac"] == pytest.approx(
-            1.0, abs=1e-6
-        ), "strand_plus_frac should be 1.0 for a forward-strand group"
-        assert df.loc[0, "strand_minus_frac"] == pytest.approx(
-            0.0, abs=1e-6
-        ), "strand_minus_frac should be 0.0 for a forward-strand group"
+        assert df.loc[0, "length_ratio_max_min"] >= 1.0
 
-    def test_strand_fractions_reverse_group_issue_97(self):
-        """Regression #97: verify reverse-strand group gives correct fractions."""
-        from tests.conftest import _BASE_ORF
-
-        reverse_orf = dict(_BASE_ORF)
-        reverse_orf["strand"] = "reverse"
-        reverse_group = {"group_1": [reverse_orf, dict(reverse_orf)]}
-
+    def test_top_orf_is_longest_single_orf_group(self, single_orf_group):
+        # Single-ORF group: top scorer == longest by definition
         clf = OrfGroupClassifier()
-        df = clf.extract_group_features(reverse_group, genome_id="test")
-        assert df.loc[0, "strand_plus_frac"] == pytest.approx(0.0, abs=1e-6)
-        assert df.loc[0, "strand_minus_frac"] == pytest.approx(1.0, abs=1e-6)
+        df = clf.extract_group_features(single_orf_group, genome_id="test")
+        assert df.loc[0, "top_orf_is_longest"] == 1
+        assert df.loc[0, "length_ratio_max_min"] == pytest.approx(1.0, abs=1e-6)
 
     def test_combined_mean_within_score_range(self, two_orf_group):
         clf = OrfGroupClassifier()


### PR DESCRIPTION
## Summary

Closes #123, #124, #125, #126, #127 — conditional on benchmark passing.

## LGB OrfGroupClassifier — 31 → 26 features (#123, #125)

**Removed (7):** `strand_plus_frac`, `strand_minus_frac` (constant per group — all ORFs in a nested group share the same stop codon and therefore the same strand), and five `*_max` relative features (`rel_combined_max`, `rel_rbs_max`, `rel_codon_max`, `rel_start_max`, `rel_start_select_max`) that are always 1.0 or mathematically redundant.

**Added (2):**
- `top_orf_is_longest` — boolean: does the top-scoring ORF also have the maximum length? Strong biological prior — the true gene almost always uses the longest available ORF.
- `length_ratio_max_min` — max/min length ratio within the group: captures within-group length spread.

## HybridGeneFilter — 25 → 26 features (#124, #126, #127)

**Removed (2):** `has_kozak_like` (eukaryotic Kozak signal, always ~0 in bacteria/archaea), `length_codons` (monotone duplicate of `length_bp` and `length_log`).

**Added (3):**
- `gc_deviation` — orf_gc minus genome_gc (estimated as batch mean when not supplied): better discriminator for high-GC organisms where absolute GC is saturated.
- `gc3_content` — GC at third codon positions: strong coding periodicity signal, especially powerful for Actinobacteria (>85% GC3 in real genes vs ~72% genome average).
- `minus10_box_score` — similarity to TATAAT consensus in the -50 to -25 window upstream of ATG. Prokaryotic replacement for `has_kozak_like`. `extract_features()` accepts an optional `genome_seq` parameter; defaults to 0.0 when absent (graceful degradation).

## Promotion protocol

> **Do not merge production models until benchmarked.**

1. Retrain LGB: `python scripts/train_lgb.py` → `orf_classifier_lgb_v2.pkl`
2. Retrain Hybrid: `python scripts/train_hybrid.py` → `hybrid_best_model_v2.pkl`
3. Run `python scripts/benchmark.py --compare` — must show 0 regressions across all 4 model combinations (old LGB + old HF, old LGB + new HF, new LGB + old HF, new LGB + new HF)
4. Only then promote both and close issues

## Test plan

- [x] 421 unit tests pass (0 failed, 2 xpassed)
- [x] Feature count assertions updated: LGB 31→26, Hybrid 25→26