### PR TITLE
INFRA: superset extract_features, thresholds.json, retrain_pipeline.py (#166-168)

### DIFF
--- a/scripts/evaluation/benchmark.py
+++ b/scripts/evaluation/benchmark.py
@@ -41,7 +41,16 @@ from src.pipeline import predict_genome_from_file
 MODELS_DIR = Path(__file__).parent.parent.parent / "models"
 DATA_DIR = get_data_dir("full_dataset")
 LOG_FILE = Path(__file__).parent.parent.parent / "experiments" / "log.json"
+THRESHOLDS_FILE = MODELS_DIR / "thresholds.json"
 SEP = "=" * 85
+
+
+def _load_thresholds() -> dict:
+    """Load calibrated thresholds from models/thresholds.json."""
+    if THRESHOLDS_FILE.exists():
+        with open(THRESHOLDS_FILE) as f:
+            return json.load(f)
+    return {}
 
 
 # ── Model loading ─────────────────────────────────────────────────────────────
@@ -192,8 +201,11 @@ print(SEP)
 _lgb_path = args.lgb_path or str(MODELS_DIR / "orf_classifier_lgb.pkl")
 _hf_path = args.hf_path or str(MODELS_DIR / "hybrid_best_model.pkl")
 lgb, hf = load_models(_lgb_path, _hf_path)
-lgb_t = args.lgb_threshold if args.lgb_threshold is not None else 0.07
-hf_t = args.hf_threshold if args.hf_threshold is not None else hf.threshold
+_thresh = _load_thresholds()
+_lgb_stem = Path(_lgb_path).stem
+_hf_stem = Path(_hf_path).stem
+lgb_t = args.lgb_threshold or _thresh.get(_lgb_stem, {}).get("threshold") or 0.07
+hf_t = args.hf_threshold or _thresh.get(_hf_stem, {}).get("threshold") or hf.threshold
 
 print(f"LGB threshold: {lgb_t}  |  Hybrid threshold: {hf_t}")
 print(f"LGB model: {_lgb_path}  [{_model_hash(Path(_lgb_path))}]")

--- a/scripts/retrain_pipeline.py
+++ b/scripts/retrain_pipeline.py
@@ -1,0 +1,166 @@
+"""
+Unified retraining pipeline — train → sweep → benchmark → promote (#166).
+
+Atomic ML retraining cycle:
+  1. train_lgb.py              → orf_classifier_lgb_v2.pkl
+  2. lgb_threshold_sweep.py    → best LGB threshold
+  3. train_hybrid.py --lgb-path v2  → hybrid_best_model_v2.pkl
+  4. hybrid_threshold_sweep.py → best Hybrid threshold
+  5. benchmark.py --compare    → confirm improvement over baseline
+  6. If confirmed: promote v2 → production, update thresholds.json
+
+Run from repo root:
+    python scripts/retrain_pipeline.py [--seed 42] [--epochs 50] [--skip-hybrid]
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+MODELS = REPO / "models"
+SCRIPTS = REPO / "scripts"
+THRESHOLDS_FILE = MODELS / "thresholds.json"
+PYTHON = sys.executable
+SEP = "=" * 70
+
+
+def run(cmd: list, step: str) -> None:
+    print(f"\n{SEP}\nSTEP: {step}\nCMD:  {' '.join(str(c) for c in cmd)}\n{SEP}")
+    result = subprocess.run(cmd, cwd=REPO)
+    if result.returncode != 0:
+        print(f"\n[ERROR] '{step}' failed (exit {result.returncode}). Aborting.")
+        sys.exit(result.returncode)
+
+
+def read_threshold(output_file: Path) -> float | None:
+    """Parse recommended threshold from a sweep output file."""
+    import re
+
+    if not output_file.exists():
+        return None
+    for line in output_file.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if "RECOMMENDED" in line:
+            m = re.search(r"t=([0-9.]+)", line)
+            if m:
+                return float(m.group(1))
+    return None
+
+
+def load_thresholds() -> dict:
+    return json.load(open(THRESHOLDS_FILE)) if THRESHOLDS_FILE.exists() else {}
+
+
+def save_thresholds(data: dict) -> None:
+    json.dump(data, open(THRESHOLDS_FILE, "w"), indent=2)
+    print(f"  Updated {THRESHOLDS_FILE.name}")
+
+
+parser = argparse.ArgumentParser(description="Atomic ML retraining pipeline.")
+parser.add_argument("--seed", type=int, default=42)
+parser.add_argument("--epochs", type=int, default=50)
+parser.add_argument("--limit", type=int, default=0, help="Genomes per group (0=all)")
+parser.add_argument("--skip-hybrid", action="store_true")
+parser.add_argument("--target-prec", type=float, default=None)
+args = parser.parse_args()
+
+lgb_v2 = MODELS / "orf_classifier_lgb_v2.pkl"
+hf_v2 = MODELS / "hybrid_best_model_v2.pkl"
+lgb_sweep_out = REPO / "lgb_sweep_v2.txt"
+hf_sweep_out = REPO / "hybrid_sweep_v2.txt"
+
+print(f"\n{'='*70}\nRETRAIN PIPELINE  seed={args.seed}  epochs={args.epochs}\n{'='*70}")
+
+# 1. Train LGB
+lgb_cmd = [
+    PYTHON,
+    str(SCRIPTS / "training" / "train_lgb.py"),
+    "--seed",
+    str(args.seed),
+    "--no-val-compare",
+]
+if args.limit:
+    lgb_cmd += ["--limit", str(args.limit)]
+run(lgb_cmd, "Train LGB v2")
+
+# 2. Sweep LGB threshold
+sweep_cmd = [PYTHON, str(SCRIPTS / "lgb_threshold_sweep.py"), "--lgb-path", str(lgb_v2)]
+if args.target_prec:
+    sweep_cmd += ["--target-prec", str(args.target_prec)]
+with open(lgb_sweep_out, "w") as f:
+    subprocess.run(sweep_cmd, cwd=REPO, stdout=f, stderr=subprocess.STDOUT)
+lgb_t = read_threshold(lgb_sweep_out) or 0.07
+print(f"\n  LGB recommended threshold: {lgb_t}")
+
+if not args.skip_hybrid:
+    # 3. Train Hybrid
+    hf_cmd = [
+        PYTHON,
+        str(SCRIPTS / "training" / "train_hybrid.py"),
+        "--lgb-path",
+        str(lgb_v2),
+        "--seed",
+        str(args.seed),
+        "--epochs",
+        str(args.epochs),
+        "--no-compare",
+    ]
+    if args.limit:
+        hf_cmd += ["--limit", str(args.limit)]
+    run(hf_cmd, "Train Hybrid v2")
+
+    # 4. Sweep Hybrid threshold
+    hf_cmd2 = [PYTHON, str(SCRIPTS / "hybrid_threshold_sweep.py")]
+    if args.target_prec:
+        hf_cmd2 += ["--target-prec", str(args.target_prec)]
+    with open(hf_sweep_out, "w") as f:
+        subprocess.run(hf_cmd2, cwd=REPO, stdout=f, stderr=subprocess.STDOUT)
+    hf_t = read_threshold(hf_sweep_out) or 0.25
+    print(f"  Hybrid recommended threshold: {hf_t}")
+else:
+    hf_v2 = MODELS / "hybrid_best_model.pkl"
+    hf_t = load_thresholds().get("hybrid_best_model", {}).get("threshold", 0.25)
+    print(f"\n  Hybrid skipped — using production model (t={hf_t})")
+
+# 5. Benchmark
+bm_cmd = [
+    PYTHON,
+    str(SCRIPTS / "evaluation" / "benchmark.py"),
+    "--lgb-path",
+    str(lgb_v2),
+    "--lgb-threshold",
+    str(lgb_t),
+    "--hf-path",
+    str(hf_v2),
+    "--hf-threshold",
+    str(hf_t),
+    "--save",
+    f"retrain seed={args.seed} epochs={args.epochs}",
+    "--compare",
+]
+run(bm_cmd, "Benchmark new pipeline")
+
+# 6. Promote
+print(f"\n{SEP}\nCheck benchmark output above.\n{SEP}")
+answer = input("\nPromote v2 models to production? [y/N] ").strip().lower()
+if answer != "y":
+    print("Cancelled.  v2 models saved as *_v2.pkl.")
+    sys.exit(0)
+
+shutil.copy(MODELS / "orf_classifier_lgb.pkl", MODELS / "orf_classifier_lgb_v1_backup.pkl")
+shutil.copy(MODELS / "hybrid_best_model.pkl", MODELS / "hybrid_best_model_v1_backup.pkl")
+shutil.copy(lgb_v2, MODELS / "orf_classifier_lgb.pkl")
+if not args.skip_hybrid:
+    shutil.copy(hf_v2, MODELS / "hybrid_best_model.pkl")
+
+thresh = load_thresholds()
+thresh["orf_classifier_lgb"]["threshold"] = lgb_t
+if not args.skip_hybrid:
+    thresh["hybrid_best_model"]["threshold"] = hf_t
+save_thresholds(thresh)
+
+print(f"\n  Promoted.  LGB t={lgb_t}" + (f"  Hybrid t={hf_t}" if not args.skip_hybrid else ""))
+print("  Update models/MODEL_LOG.md with provenance.")

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -160,6 +160,9 @@ class OrfGroupClassifier:
             max_start = start.max()
             max_ss = ss.max()
 
+            # Superset: always compute ALL known features across every model
+            # generation so predict_groups() can select what it needs.
+            strands = orf_group["strand"].tolist()
             group_features = {
                 "group_id": group_id,
                 "num_orfs": n,
@@ -181,7 +184,17 @@ class OrfGroupClassifier:
                 "imm_mean": imm.mean(),
                 "start_select_max": max_ss,
                 "start_select_mean": ss.mean(),
-                # Relative-mean features (max variants removed — always 1.0 or redundant)
+                # v1 features kept for backward compat with old models
+                "strand_plus_frac": strands.count("forward") / n,
+                "strand_minus_frac": strands.count("reverse") / n,
+                "rel_combined_max": (
+                    combined / max_combined if max_combined > 0 else np.zeros(n)
+                ).max(),
+                "rel_rbs_max": (rbs / max_rbs if max_rbs > 0 else np.zeros(n)).max(),
+                "rel_codon_max": (codon / max_codon if max_codon > 0 else np.zeros(n)).max(),
+                "rel_start_max": (start / max_start if max_start > 0 else np.zeros(n)).max(),
+                "rel_start_select_max": (ss / max_ss if max_ss > 0 else np.zeros(n)).max(),
+                # Current features
                 "rel_combined_mean": (
                     combined / max_combined if max_combined > 0 else np.zeros(n)
                 ).mean(),
@@ -189,7 +202,6 @@ class OrfGroupClassifier:
                 "rel_codon_mean": (codon / max_codon if max_codon > 0 else np.zeros(n)).mean(),
                 "rel_start_mean": (start / max_start if max_start > 0 else np.zeros(n)).mean(),
                 "rel_start_select_mean": (ss / max_ss if max_ss > 0 else np.zeros(n)).mean(),
-                # Biological priors: longest ORF is usually the true gene in nested groups
                 "top_orf_is_longest": int(combined.argmax() == lengths.argmax()),
                 "length_ratio_max_min": float(lengths.max() / max(lengths.min(), 1.0)),
                 "frac_top_combined": (combined >= 0.95 * max_combined).sum() / n,


### PR DESCRIPTION
Closes #166, #167, #168.

## #167 — Superset `extract_features` (eliminates feature compat hell)

`OrfGroupClassifier.extract_group_features()` now always returns ALL 33 known features (31 v1 + `top_orf_is_longest` + `length_ratio_max_min`). `predict_groups()` selects only what the loaded model needs via `self.feature_names`. Old models and new models coexist without any legacy compat hacks, extra fields, or error-prone version detection.

Same design applied to `HybridGeneFilter.extract_features()` — always computes the full superset including legacy `has_kozak_like` and `length_codons`.

## #168 — `models/thresholds.json`

Calibrated thresholds are now stored in a single readable file:
```json
{"orf_classifier_lgb": {"threshold": 0.05, ...}, "hybrid_best_model": {"threshold": 0.471, ...}}
```
`benchmark.py` reads from it as the default (CLI `--lgb-threshold`/`--hf-threshold` still override). `retrain_pipeline.py` updates it on promotion.

## #166 — `scripts/retrain_pipeline.py`

Single-command atomic workflow:
```
python scripts/retrain_pipeline.py [--seed 42] [--epochs 50] [--skip-hybrid]
```
Steps: train LGB → sweep LGB threshold → train Hybrid → sweep Hybrid threshold → benchmark → prompt to promote. Prevents the "forgot to sweep threshold" and "wrong model comparison" errors that plagued the v2 training.