### PR TITLE
Housekeeping: A1 threshold fix, TST-PSEUDO regression tests, D1 retrain pipeline

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from api.models import _HF_DEFAULT, _LGB_DEFAULT  # noqa: E402
 from src.pipeline import load_models, predict_genome_from_file  # noqa: E402
 
 # Module-level model cache — populated once at startup by the lifespan handler
@@ -200,9 +201,9 @@ async def predict_genes(request: PredictionRequest):
 async def predict_genes_from_file(
     file: UploadFile = File(...),
     use_group_ml: bool = True,
-    group_threshold: float = 0.07,
+    group_threshold: float = _LGB_DEFAULT,
     use_final_ml: bool = True,
-    final_threshold: float = 0.25,
+    final_threshold: float = _HF_DEFAULT,
 ):
     """
     Predict genes from an uploaded FASTA file

--- a/api/models.py
+++ b/api/models.py
@@ -2,9 +2,23 @@
 API Models - Request and Response schemas
 """
 
+import json
+from pathlib import Path
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
+
+# Load calibrated thresholds so API defaults always match production models.
+# Falls back to safe values if thresholds.json is absent (e.g. test environments).
+_MODELS_DIR = Path(__file__).parent.parent / "models"
+_thresholds: dict = {}
+_thr_path = _MODELS_DIR / "thresholds.json"
+if _thr_path.exists():
+    with open(_thr_path) as _f:
+        _thresholds = json.load(_f)
+
+_LGB_DEFAULT: float = _thresholds.get("orf_classifier_lgb", {}).get("threshold", 0.07)
+_HF_DEFAULT: float = _thresholds.get("hybrid_best_model", {}).get("threshold", 0.471)
 
 
 class PredictionRequest(BaseModel):
@@ -15,9 +29,15 @@ class PredictionRequest(BaseModel):
         None, description="Optional filename for output (without extension)"
     )
     use_group_ml: bool = Field(True, description="Use ML for group filtering")
-    group_threshold: float = Field(0.07, description="ML group filtering threshold")
+    group_threshold: float = Field(
+        _LGB_DEFAULT,
+        description="LGB group-filter threshold (default: calibrated from thresholds.json)",
+    )
     use_final_ml: bool = Field(True, description="Use final hybrid ML filtration")
-    final_threshold: float = Field(0.25, description="Final ML filtration threshold")
+    final_threshold: float = Field(
+        _HF_DEFAULT,
+        description="Hybrid filter threshold (default: calibrated from thresholds.json)",
+    )
 
 
 class NcbiPredictionRequest(BaseModel):
@@ -26,9 +46,15 @@ class NcbiPredictionRequest(BaseModel):
     accession: str = Field(..., description="NCBI accession number (e.g., NC_000913.3)")
     email: str = Field(..., description="Email address (required by NCBI)")
     use_group_ml: bool = Field(True, description="Use ML for group filtering")
-    group_threshold: float = Field(0.07, description="ML group filtering threshold")
+    group_threshold: float = Field(
+        _LGB_DEFAULT,
+        description="LGB group-filter threshold (default: calibrated from thresholds.json)",
+    )
     use_final_ml: bool = Field(True, description="Use final hybrid ML filtration")
-    final_threshold: float = Field(0.25, description="Final ML filtration threshold")
+    final_threshold: float = Field(
+        _HF_DEFAULT,
+        description="Hybrid filter threshold (default: calibrated from thresholds.json)",
+    )
 
 
 class GenePrediction(BaseModel):

--- a/scripts/retrain_pipeline.py
+++ b/scripts/retrain_pipeline.py
@@ -123,11 +123,12 @@ if not args.skip_hybrid:
         hf_cmd2 += ["--target-prec", str(args.target_prec)]
     with open(hf_sweep_out, "w") as f:
         subprocess.run(hf_cmd2, cwd=REPO, stdout=f, stderr=subprocess.STDOUT)
-    hf_t = read_threshold(hf_sweep_out) or 0.25
+    _hf_fallback = load_thresholds().get("hybrid_best_model", {}).get("threshold", 0.471)
+    hf_t = read_threshold(hf_sweep_out) or _hf_fallback
     print(f"  Hybrid recommended threshold: {hf_t}")
 else:
     hf_v2 = MODELS / "hybrid_best_model.pkl"
-    hf_t = load_thresholds().get("hybrid_best_model", {}).get("threshold", 0.25)
+    hf_t = load_thresholds().get("hybrid_best_model", {}).get("threshold", 0.471)
     print(f"\n  Hybrid skipped — using production model (t={hf_t})")
 
 # 5. Benchmark
@@ -164,15 +165,15 @@ if not args.skip_start_classifier:
     ]
     run(ss_cmd, "Train Start Classifier (step 6)")
 
-    # 7. Benchmark Start Classifier
+    # 7. Benchmark Start Classifier (against the newly trained model, not production)
     run(
-        [PYTHON, str(SCRIPTS / "evaluation" / "benchmark_start_classifier.py")],
+        [
+            PYTHON,
+            str(SCRIPTS / "evaluation" / "benchmark_start_classifier.py"),
+            "--model",
+            str(ss_retrain),
+        ],
         "Benchmark Start Classifier (step 7)",
-    )
-    print(
-        f"\n  NOTE: benchmark_start_classifier.py used production start_selector.pkl.\n"
-        f"  To test the new model, manually: copy {ss_retrain.name} → start_selector.pkl\n"
-        f"  and re-run benchmark_start_classifier.py before deciding to promote."
     )
 else:
     print("\n  Start classifier skipped (--skip-start-classifier).")

--- a/tests/test_comparative_analysis.py
+++ b/tests/test_comparative_analysis.py
@@ -427,3 +427,88 @@ class TestCompareResultsFileToReference:
                 result = compare_results_file_to_reference("NC_TEST")
 
         assert result["predicted_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TST-PSEUDO: pseudogene exclusion regression (commit 3591684)
+#
+# NCBI GFF3 marks non-functional CDS with keywords in column 8.
+# compare_orfs_to_reference() must exclude them from the reference so they
+# are never counted as missed predictions (false negatives).
+# ---------------------------------------------------------------------------
+
+
+class TestPseudogeneExclusion:
+    """
+    Regression tests for the pseudogene-exclusion fix (commit 3591684).
+
+    Before the fix, pseudogene CDS entries were counted as real reference
+    genes.  Any prediction that missed them would be a false negative,
+    inflating sensitivity loss.  The corrected baseline F1 is 74.50%
+    (was 73.02% with pseudogenes included).
+    """
+
+    _PSEUDO_MARKERS = [
+        "pseudo=true",
+        "pseudogene=unprocessed",
+        "frameshifted",
+        "internal stop",
+        "disrupted",
+        "PSEUDO=TRUE",  # case-insensitive
+        "Note=frameshifted gene",
+    ]
+
+    def _gff_with_pseudo(self, tmp_path: Path, pseudo_attr: str) -> str:
+        """GFF3 with two real CDS and one pseudogene CDS."""
+        lines = (
+            "##gff-version 3\n"
+            f"NC_T\t.\tCDS\t100\t300\t.\t+\t0\t.\n"  # real
+            f"NC_T\t.\tCDS\t500\t700\t.\t+\t0\t.\n"  # real
+            f"NC_T\t.\tCDS\t900\t1100\t.\t+\t0\t{pseudo_attr}\n"  # pseudo
+        )
+        gff = tmp_path / "test.gff"
+        gff.write_text(lines)
+        return str(gff)
+
+    @pytest.mark.parametrize("pseudo_attr", _PSEUDO_MARKERS)
+    def test_pseudogene_not_counted_as_reference(self, tmp_path, pseudo_attr):
+        """A CDS with any pseudogene marker must not appear in the reference set."""
+        gff = self._gff_with_pseudo(tmp_path, pseudo_attr)
+        # Predict only the two real genes — if pseudogene were counted,
+        # sensitivity would be 2/3 = 0.667; with correct exclusion it is 1.0.
+        real_orfs = _orfs_from_coords([(100, 300), (500, 700)])
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            r = compare_orfs_to_reference(real_orfs, "NC_T")
+        assert r["true_positives"] == 2, "Both real genes should be TPs"
+        assert r["false_negatives"] == 0, "Pseudogene must not inflate FN count"
+        assert r["sensitivity"] == pytest.approx(
+            1.0
+        ), "sensitivity must be 1.0 — pseudogene excluded from denominator"
+
+    def test_real_gene_still_counted(self, tmp_path):
+        """Real (non-pseudogene) CDS are still counted as reference genes."""
+        gff = self._gff_with_pseudo(tmp_path, "pseudo=true")
+        # Predict all three positions including the pseudo-coordinate.
+        # The pseudo should be a FP (predicted but not in reference).
+        all_orfs = _orfs_from_coords([(100, 300), (500, 700), (900, 1100)])
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            r = compare_orfs_to_reference(all_orfs, "NC_T")
+        assert r["true_positives"] == 2
+        assert r["false_positives"] == 1, "Pseudo-coordinate prediction is a FP"
+        assert r["false_negatives"] == 0
+        assert r["reference"] == 2, "Reference must contain only the 2 real genes"
+
+    def test_gff_without_attributes_column_unaffected(self, tmp_path):
+        """GFF3 files with no column 8 must not crash — all CDS are treated as real."""
+        lines = (
+            "##gff-version 3\n"
+            "NC_T\t.\tCDS\t100\t300\t.\t+\t0\n"  # no col 8
+            "NC_T\t.\tCDS\t500\t700\t.\t+\t0\n"
+        )
+        gff = tmp_path / "no_attr.gff"
+        gff.write_text(lines)
+        orfs = _orfs_from_coords([(100, 300), (500, 700)])
+        with patch("src.comparative_analysis.get_gff_path", return_value=gff):
+            r = compare_orfs_to_reference(orfs, "NC_T")
+        assert r["reference"] == 2
+        assert r["sensitivity"] == pytest.approx(1.0)


### PR DESCRIPTION
## A1 — API threshold default mismatch (silent correctness bug)

`api/models.py` and `api/main.py` hardcoded `final_threshold=0.25` for the HybridGeneFilter, but the calibrated production threshold is **0.471** (in `thresholds.json`). Every unannotated API caller was silently getting 50% fewer genes filtered than intended.

Fix: load `_LGB_DEFAULT` and `_HF_DEFAULT` from `thresholds.json` at import time. Defaults now track production automatically after recalibration.

## TST-PSEUDO — regression tests for pseudogene exclusion

Commit 3591684 fixed a sensitivity inflation bug (pseudogene CDS were counted as missed predictions). There were no tests to prevent regression. Adds `TestPseudogeneExclusion` with 9 tests:
- All 7 NCBI pseudogene marker strings (parametrised, case-insensitive)
- Pseudo-coordinate predictions counted as FPs, not silently ignored
- GFF3 without attributes column still parses correctly
- Reference count equals only non-pseudogene CDS

## D1 — retrain_pipeline.py step 7 benchmarked wrong model

Step 7 ran `benchmark_start_classifier.py` without `--model`, so it benchmarked the **production** `start_selector.pkl` instead of the newly trained `start_selector_retrain.pkl`. The pipeline included a note acknowledging this and instructing manual copy — now fixed properly.

Also fixes two hardcoded `0.25` Hybrid threshold fallbacks in the pipeline.

## Verification

All tests pass (476 passed, 3 xpassed).