### PR TITLE
FIX(A1+D1): API threshold defaults + retrain pipeline model benchmark fix

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from api.models import _HF_DEFAULT, _LGB_DEFAULT  # noqa: E402
 from src.pipeline import load_models, predict_genome_from_file  # noqa: E402
 
 # Module-level model cache — populated once at startup by the lifespan handler
@@ -200,9 +201,9 @@ async def predict_genes(request: PredictionRequest):
 async def predict_genes_from_file(
     file: UploadFile = File(...),
     use_group_ml: bool = True,
-    group_threshold: float = 0.07,
+    group_threshold: float = _LGB_DEFAULT,
     use_final_ml: bool = True,
-    final_threshold: float = 0.25,
+    final_threshold: float = _HF_DEFAULT,
 ):
     """
     Predict genes from an uploaded FASTA file

--- a/api/models.py
+++ b/api/models.py
@@ -2,9 +2,22 @@
 API Models - Request and Response schemas
 """
 
+import json
+from pathlib import Path
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
+
+# Load calibrated thresholds so API defaults always match production models.
+# Falls back to safe values if thresholds.json is absent (e.g. test environments).
+_thresholds: dict = {}
+_thr_path = Path(__file__).parent.parent / "models" / "thresholds.json"
+if _thr_path.exists():
+    with open(_thr_path) as _f:
+        _thresholds = json.load(_f)
+
+_LGB_DEFAULT: float = _thresholds.get("orf_classifier_lgb", {}).get("threshold", 0.07)
+_HF_DEFAULT: float = _thresholds.get("hybrid_best_model", {}).get("threshold", 0.471)
 
 
 class PredictionRequest(BaseModel):
@@ -15,9 +28,13 @@ class PredictionRequest(BaseModel):
         None, description="Optional filename for output (without extension)"
     )
     use_group_ml: bool = Field(True, description="Use ML for group filtering")
-    group_threshold: float = Field(0.07, description="ML group filtering threshold")
+    group_threshold: float = Field(
+        _LGB_DEFAULT, description="LGB group-filter threshold (calibrated from thresholds.json)"
+    )
     use_final_ml: bool = Field(True, description="Use final hybrid ML filtration")
-    final_threshold: float = Field(0.25, description="Final ML filtration threshold")
+    final_threshold: float = Field(
+        _HF_DEFAULT, description="Hybrid filter threshold (calibrated from thresholds.json)"
+    )
 
 
 class NcbiPredictionRequest(BaseModel):
@@ -26,9 +43,13 @@ class NcbiPredictionRequest(BaseModel):
     accession: str = Field(..., description="NCBI accession number (e.g., NC_000913.3)")
     email: str = Field(..., description="Email address (required by NCBI)")
     use_group_ml: bool = Field(True, description="Use ML for group filtering")
-    group_threshold: float = Field(0.07, description="ML group filtering threshold")
+    group_threshold: float = Field(
+        _LGB_DEFAULT, description="LGB group-filter threshold (calibrated from thresholds.json)"
+    )
     use_final_ml: bool = Field(True, description="Use final hybrid ML filtration")
-    final_threshold: float = Field(0.25, description="Final ML filtration threshold")
+    final_threshold: float = Field(
+        _HF_DEFAULT, description="Hybrid filter threshold (calibrated from thresholds.json)"
+    )
 
 
 class GenePrediction(BaseModel):

--- a/scripts/retrain_pipeline.py
+++ b/scripts/retrain_pipeline.py
@@ -123,11 +123,13 @@ if not args.skip_hybrid:
         hf_cmd2 += ["--target-prec", str(args.target_prec)]
     with open(hf_sweep_out, "w") as f:
         subprocess.run(hf_cmd2, cwd=REPO, stdout=f, stderr=subprocess.STDOUT)
-    hf_t = read_threshold(hf_sweep_out) or 0.25
+    hf_t = read_threshold(hf_sweep_out) or load_thresholds().get("hybrid_best_model", {}).get(
+        "threshold", 0.471
+    )
     print(f"  Hybrid recommended threshold: {hf_t}")
 else:
     hf_v2 = MODELS / "hybrid_best_model.pkl"
-    hf_t = load_thresholds().get("hybrid_best_model", {}).get("threshold", 0.25)
+    hf_t = load_thresholds().get("hybrid_best_model", {}).get("threshold", 0.471)
     print(f"\n  Hybrid skipped — using production model (t={hf_t})")
 
 # 5. Benchmark
@@ -164,15 +166,15 @@ if not args.skip_start_classifier:
     ]
     run(ss_cmd, "Train Start Classifier (step 6)")
 
-    # 7. Benchmark Start Classifier
+    # 7. Benchmark Start Classifier (uses newly trained model, not production)
     run(
-        [PYTHON, str(SCRIPTS / "evaluation" / "benchmark_start_classifier.py")],
+        [
+            PYTHON,
+            str(SCRIPTS / "evaluation" / "benchmark_start_classifier.py"),
+            "--model",
+            str(ss_retrain),
+        ],
         "Benchmark Start Classifier (step 7)",
-    )
-    print(
-        f"\n  NOTE: benchmark_start_classifier.py used production start_selector.pkl.\n"
-        f"  To test the new model, manually: copy {ss_retrain.name} → start_selector.pkl\n"
-        f"  and re-run benchmark_start_classifier.py before deciding to promote."
     )
 else:
     print("\n  Start classifier skipped (--skip-start-classifier).")


### PR DESCRIPTION
## A1 — API threshold default mismatch (silent correctness bug)

`api/models.py` and `api/main.py` hardcoded `final_threshold=0.25` for the HybridGeneFilter. The calibrated production threshold is **0.471** (in `thresholds.json`). Every unannotated API caller was silently getting a more permissive filter than intended, producing extra false positives.

**Fix:** load `_LGB_DEFAULT` and `_HF_DEFAULT` from `thresholds.json` at import time. Defaults now track production automatically after any recalibration.

## D1 — retrain_pipeline.py step 7 benchmarked wrong model

Step 7 ran `benchmark_start_classifier.py` without `--model`, so it benchmarked the **production** `start_selector.pkl` instead of the newly trained `start_selector_retrain.pkl`. The pipeline included a NOTE acknowledging this and instructing manual copy — now fixed.

Also fixes two hardcoded `0.25` Hybrid threshold fallbacks to read from `thresholds.json` (0.471).